### PR TITLE
Add light grey backgrounds to improve readability 

### DIFF
--- a/src/ComboGrid.tsx
+++ b/src/ComboGrid.tsx
@@ -93,7 +93,7 @@ export const ComboGrid = () => {
       <div id="is-cog-lured">
         <button
           onClick={onClickToggleLure}
-          style={{ background: store.getIsLured() ? 'var(--lure)' : 'unset' }}
+          style={{ background: store.getIsLured() ? 'var(--lure)' : 'var(--lightgrey)' }}
         >
           <img src={util.getGagIconUrl({ track: 'lure', lvl: 1 }) /* $1 bill icon */} />
           <span>Is Cog Lured?</span>

--- a/src/OrgGagTrackSelect.tsx
+++ b/src/OrgGagTrackSelect.tsx
@@ -57,7 +57,7 @@ type GagTrackListItemProps = {
 const GagTrackListItem = (props: GagTrackListItemProps) => {
   const background = () => props.isGagTrackSelected
     ? `var(--${props.gagTrack})`
-    : 'transparent';
+    : 'var(--lightgrey)';
 
   return (
     <li role="option" style={{ background: background() }}>

--- a/src/index.css
+++ b/src/index.css
@@ -341,6 +341,7 @@ h1, h2, h3, h4, h5, h6 {
   border: 1px solid black;
   height: 1.6rem;
   padding: 0 1rem;
+  background: var(--lightgrey);
 }
 
 #is-cog-lured {
@@ -354,6 +355,7 @@ h1, h2, h3, h4, h5, h6 {
   border: 1px solid black;
   font-size: 0.9em;
   padding: 0 0.2em;
+  background: var(--lightgrey);
 }
 
 #is-cog-lured button {
@@ -504,6 +506,7 @@ h1, h2, h3, h4, h5, h6 {
   border: 3px solid black;
   text-align: center;
   padding: 0.2rem;
+  background: var(--lightgrey);
 }
 
 .cogs-hp-lvl {
@@ -551,6 +554,7 @@ h1, h2, h3, h4, h5, h6 {
   align-items: center;
   padding: 0.5rem;
   gap: 0.7rem;
+  background: var(--lightgrey);
 }
 
 #combo-info-result-dmg-label {
@@ -581,6 +585,7 @@ h1, h2, h3, h4, h5, h6 {
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
+  background: var(--lightgrey);
 }
 
 .selected-gag-img-and-name {


### PR DESCRIPTION
Hi there. I love this calculator but it is very difficult and annoying to see the information since there is no background behind a lot of the text. I added light grey backgrounds (pulled from the sos toon backgrounds) to the buttons and calculator results to fix this. 