### PR TITLE
calculator: shade and highlight gag rows and cells 

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -175,8 +175,8 @@ button:not([disabled]) {
 }
 
 button:focus:not(:focus-visible) {
-  outline: 0 !important;
-  box-shadow: none !important;
+  outline: 0;
+  box-shadow: none;
 }
 
 ul {

--- a/src/index.css
+++ b/src/index.css
@@ -507,8 +507,8 @@ h1, h2, h3, h4, h5, h6 {
 
 .calc-gag-grid-cell:hover {
   box-shadow: inset 0 -1px 9px 2px var(--gag-highlight-blue),
-    0 0px 0px var(--gag-shadow-blue);
-  border-bottom: 1px solid var(--gag-shadow-blue);
+    0 0px 0px var(--gag-shadow-blue) !important;
+  border-bottom: 1px solid var(--gag-shadow-blue) !important;
 }
 
 .calc-gag-grid-cell img {

--- a/src/index.css
+++ b/src/index.css
@@ -505,6 +505,7 @@ h6 {
   justify-content: center;
   background: var(--gag-bg-blue);
   border-radius: 5px;
+  border-top: 1.5px solid var(--gag-highlight-blue);
   border-bottom: 1.5px solid var(--gag-shadow-blue);
   outline: 2px solid var(--gag-shadow-blue);
   box-shadow: inset 0 0 6px var(--gag-highlight-blue),

--- a/src/index.css
+++ b/src/index.css
@@ -500,9 +500,9 @@ h1, h2, h3, h4, h5, h6 {
   border-radius: 5px;
   border-top: 1.5px solid var(--gag-highlight-blue);
   border-bottom: 1.5px solid var(--gag-shadow-blue);
-  outline: 2px solid var(--gag-shadow-blue);
+  outline: 2px solid var(--gag-shadow-blue) !imporant;
   box-shadow: inset 0 0 6px var(--gag-highlight-blue),
-    0 2px 3px var(--mediumgrey);
+    0 2px 3px var(--mediumgrey) !important;
 }
 
 .calc-gag-grid-cell:hover {

--- a/src/index.css
+++ b/src/index.css
@@ -674,7 +674,7 @@ html[data-theme="dark"] #additional-gag-multiplier {
 
 .selected-gag-img-container,
 .selected-org-img-container,
-.selected-gag-lvl-mod-img-container 
+.selected-gag-lvl-mod-img-container
 {
   background: var(--gag-bg-blue);
   padding: 0.2rem;

--- a/src/index.css
+++ b/src/index.css
@@ -512,6 +512,12 @@ h6 {
     0 2px 3px var(--mediumgrey);
 }
 
+.calc-gag-grid-cell:hover {
+  box-shadow: inset 0 -1px 9px 2px var(--gag-highlight-blue),
+    0 0px 0px var(--gag-shadow-blue);
+  border-bottom: 1px solid var(--gag-shadow-blue);
+}
+
 .calc-gag-grid-cell img {
   aspect-ratio: 1 / 1;
   max-width: min(70%, 30px);

--- a/src/index.css
+++ b/src/index.css
@@ -483,7 +483,7 @@ h6 {
   grid-template-columns: repeat(9, 1fr);
   gap: 0.4rem;
   padding: 0.4rem;
-  gap: 0.4rem;
+  gap: 0.5rem;
   width: 100%;
   border-radius: 5px;
   box-shadow: inset 0 -8px 0 rgba(5, 5, 5, 0.15);

--- a/src/index.css
+++ b/src/index.css
@@ -486,6 +486,7 @@ h6 {
   gap: 0.4rem;
   width: 100%;
   border-radius: 5px;
+  box-shadow: inset 0 -8px 0 rgba(5, 5, 5, 0.15);
 }
 
 .calc-gag-row-track-label {

--- a/src/index.css
+++ b/src/index.css
@@ -11,16 +11,18 @@
   --mediumgrey: #313131;
   --darkgrey: #262626;
   --black: #181818;
+  --gag-shadow-blue: #1c78b2;
+  --gag-highlight-blue: #8cd1ff;
 }
 
 html[data-theme="light"] {
-   --color-bg: var(--lightgrey);
-   --color-fg: var(--black);
+  --color-bg: var(--lightgrey);
+  --color-fg: var(--black);
 }
 
 html[data-theme="dark"] {
-   --color-bg: var(--mediumgrey);
-   --color-fg: var(--lightgrey);
+  --color-bg: var(--mediumgrey);
+  --color-fg: var(--lightgrey);
 }
 
 * {
@@ -48,7 +50,7 @@ body {
 }
 
 html[data-theme="dark"] body::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: 0;
@@ -182,7 +184,12 @@ ul {
   padding: 0;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-weight: 400;
   text-align: center;
 }
@@ -257,7 +264,7 @@ h1, h2, h3, h4, h5, h6 {
   display: grid;
   grid-column-gap: 20px;
   width: 100%;
-  overflow-x: auto;;
+  overflow-x: auto;
   overflow-y: hidden;
   padding: 0 1rem;
 }
@@ -281,7 +288,8 @@ h1, h2, h3, h4, h5, h6 {
   right: 0;
   font-size: 0.3em;
   color: white;
-  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000,
+    1px 1px 0 #000;
 }
 
 .cog-icon-container span {
@@ -384,7 +392,8 @@ h1, h2, h3, h4, h5, h6 {
   margin: 0.5rem;
 }
 
-#is-cog-lured button, #clear-selection {
+#is-cog-lured button,
+#clear-selection {
   border-radius: 5px;
   border: 2px solid var(--black);
   font-size: 0.9em;
@@ -495,6 +504,10 @@ h1, h2, h3, h4, h5, h6 {
   justify-content: center;
   background: var(--gag-bg-blue);
   border-radius: 5px;
+  border-bottom: 1.5px solid var(--gag-shadow-blue);
+  outline: 2px solid var(--gag-shadow-blue);
+  box-shadow: inset 0 0 6px var(--gag-highlight-blue),
+    0 2px 3px var(--mediumgrey);
 }
 
 .calc-gag-grid-cell img {
@@ -560,7 +573,6 @@ html[data-theme="dark"] .cogs-hp-cell {
 #additional-gag-multiplier {
   margin-bottom: 1rem;
 }
-
 
 html[data-theme="dark"] #additional-gag-multiplier {
   background: var(--black);
@@ -660,8 +672,7 @@ html[data-theme="dark"] #additional-gag-multiplier {
 
 .selected-gag-img-container,
 .selected-org-img-container,
-.selected-gag-lvl-mod-img-container
-{
+.selected-gag-lvl-mod-img-container {
   background: var(--gag-bg-blue);
   padding: 0.2rem;
   border-radius: 5px;
@@ -734,4 +745,3 @@ html[data-theme="dark"] #additional-gag-multiplier {
     display: none;
   }
 }
-

--- a/src/index.css
+++ b/src/index.css
@@ -16,13 +16,13 @@
 }
 
 html[data-theme="light"] {
-  --color-bg: var(--lightgrey);
-  --color-fg: var(--black);
+   --color-bg: var(--lightgrey);
+   --color-fg: var(--black);
 }
 
 html[data-theme="dark"] {
-  --color-bg: var(--mediumgrey);
-  --color-fg: var(--lightgrey);
+   --color-bg: var(--mediumgrey);
+   --color-fg: var(--lightgrey);
 }
 
 * {
@@ -50,7 +50,7 @@ body {
 }
 
 html[data-theme="dark"] body::before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0;
   left: 0;
@@ -184,12 +184,7 @@ ul {
   padding: 0;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+h1, h2, h3, h4, h5, h6 {
   font-weight: 400;
   text-align: center;
 }
@@ -264,7 +259,7 @@ h6 {
   display: grid;
   grid-column-gap: 20px;
   width: 100%;
-  overflow-x: auto;
+  overflow-x: auto;;
   overflow-y: hidden;
   padding: 0 1rem;
 }
@@ -288,8 +283,7 @@ h6 {
   right: 0;
   font-size: 0.3em;
   color: white;
-  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000,
-    1px 1px 0 #000;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
 }
 
 .cog-icon-container span {
@@ -392,8 +386,7 @@ h6 {
   margin: 0.5rem;
 }
 
-#is-cog-lured button,
-#clear-selection {
+#is-cog-lured button, #clear-selection {
   border-radius: 5px;
   border: 2px solid var(--black);
   font-size: 0.9em;
@@ -582,6 +575,7 @@ html[data-theme="dark"] .cogs-hp-cell {
   margin-bottom: 1rem;
 }
 
+
 html[data-theme="dark"] #additional-gag-multiplier {
   background: var(--black);
   color: inherit;
@@ -680,7 +674,8 @@ html[data-theme="dark"] #additional-gag-multiplier {
 
 .selected-gag-img-container,
 .selected-org-img-container,
-.selected-gag-lvl-mod-img-container {
+.selected-gag-lvl-mod-img-container 
+{
   background: var(--gag-bg-blue);
   padding: 0.2rem;
   border-radius: 5px;
@@ -753,3 +748,4 @@ html[data-theme="dark"] #additional-gag-multiplier {
     display: none;
   }
 }
+


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/518dc984-d93f-4e74-991e-f737f3f1a10b)

Adds slight shading and highlights to gag rows and cells per some points in #41 

Furthermore, this adds a hover effect that slightly highlights what cell you're over and removes the shadow, as seen below:
![image](https://github.com/user-attachments/assets/e8e358f5-5121-4fa1-8ad0-cac09cb56d69)

