### PR TITLE
Boiler damage tracking

### DIFF
--- a/src/Calculator/AccumulatedDamageCombo.module.css
+++ b/src/Calculator/AccumulatedDamageCombo.module.css
@@ -1,0 +1,48 @@
+.container {
+  padding: 0.5rem;
+  border-radius: 5px;
+  border: 4px solid var(--black);
+}
+
+.flexContainer {
+  display: flex;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.organicIcon {
+  position: absolute;
+  bottom: 1px;
+  right: 1px;
+  max-height: 45% !important;
+  max-width: 45% !important;
+}
+
+.damage {
+  width: min-content;
+  text-align: center;
+  margin-left: auto;
+}
+
+.damageValue {
+  font-size: 1.8rem;
+  font-weight: bold;
+}
+
+.damageLabel {
+  font-size: 0.7rem;
+  display: block;
+}
+
+.selectedGagGroup {
+  padding: 0.5rem;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  background: var(--color-bg);
+}
+

--- a/src/Calculator/AccumulatedDamageCombo.tsx
+++ b/src/Calculator/AccumulatedDamageCombo.tsx
@@ -1,0 +1,73 @@
+import { JSX, Show, For } from 'solid-js';
+import * as util from '../util';
+import { Combo, SosToonGag } from '../gags';
+import { additionalGagMultipliers } from '../constants';
+import { SvgX } from './SvgX';
+import stylesSelectedGags from './SelectedGags.module.css';
+import stylesAccumulatedDamageCombo from './AccumulatedDamageCombo.module.css';
+
+const styles = { ...stylesSelectedGags, ...stylesAccumulatedDamageCombo };
+
+type Props = {
+  combo: Combo;
+  additionalGagMultiplier: number;
+  onClickRemove: JSX.EventHandler<HTMLButtonElement, MouseEvent>;
+};
+
+export const AccumulatedDamageCombo = (props: Props) => {
+  return (
+    <div class={styles.container}>
+      <Show when={props.additionalGagMultiplier !== 0}>
+        <div style={{ 'font-size': '0.8rem' }}>{additionalGagMultipliers[props.additionalGagMultiplier]}</div>
+        <hr style={{ border: 'none', 'border-top': `2px solid var(--black)` }} />
+      </Show>
+      <div class={styles.flexContainer}>
+        <For each={props.combo.gags}>
+          {gag => (
+            <div
+              class={styles.bgBlueBtn}
+              style={{
+                background: gag instanceof SosToonGag ? 'var(--lightgrey)' : undefined,
+                border: `2px solid ${gag instanceof SosToonGag ? 'var(--gag-bg-blue)' : 'transparent'}`,
+                position: 'relative',
+              }}
+            >
+              {gag instanceof SosToonGag
+                ? <>
+                  <img
+                    class={`${styles.gagIcon} no-drag`}
+                    src={util.getSosToonIconUrl(gag.sosToon)}
+                  />
+                  <img
+                    class={`${styles.sosToonGagIcon} no-drag`}
+                    src={util.getSosGagIconUrl(gag.sosToon)}
+                  />
+                </> : <>
+                  <img
+                    class={`${styles.gagIcon} no-drag`}
+                    src={util.getGagIconUrl({ track: gag.track, lvl: gag.lvl })}
+                  />
+                  <Show when={gag.isOrg}>
+                    <img class={styles.organicIcon} src={util.getResourceUrl('Organic.png')} />
+                  </Show>
+                </>
+              }
+            </div>
+          )}
+        </For>
+        <div class={styles.damage}>
+          <span class={styles.damageValue} id="combo-info-result-dmg">
+            {props.combo.damage({ additionalGagMultiplier: props.additionalGagMultiplier })}
+          </span>
+          <label class={styles.damageLabel} for="combo-info-result-dmg">
+            Damage
+          </label>
+        </div>
+        <button type="button" aria-label="Remove" onClick={props.onClickRemove} class={styles.xBtn}>
+          <SvgX />
+        </button>
+      </div>
+    </div>
+  );
+};
+

--- a/src/Calculator/AccumulatedDamageDisplay.module.css
+++ b/src/Calculator/AccumulatedDamageDisplay.module.css
@@ -1,0 +1,42 @@
+.innerContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+}
+
+.hr {
+  border: none;
+  border-top: 4px solid var(--black);
+  margin-top: 0;
+}
+
+.damage {
+  width: min-content;
+  text-align: center;
+}
+
+.damageValue {
+  font-size: 1.8rem;
+  font-weight: bold;
+}
+
+.damageLabel {
+  font-size: 0.7rem;
+  display: block;
+}
+
+.xBtn {
+  position: absolute;
+  right: calc(0.5rem + 4px);
+}
+
+.xBtnLabel {
+  position: absolute;
+  top: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.7rem;
+  white-space: nowrap;
+}
+

--- a/src/Calculator/AccumulatedDamageDisplay.tsx
+++ b/src/Calculator/AccumulatedDamageDisplay.tsx
@@ -1,0 +1,33 @@
+import { JSX } from 'solid-js';
+import { SvgX } from './SvgX';
+import styles from './AccumulatedDamageDisplay.module.css';
+
+type Props = {
+  accumulatedDamage: number;
+  onClickClearAll: JSX.EventHandler<HTMLButtonElement, MouseEvent>;
+};
+
+export const AccumulatedDamageDisplay = (props: Props) => {
+  return (
+    <div>
+      <hr class={styles.hr} />
+      <div class={styles.innerContainer}>
+        <div class={styles.damage}>
+          <span class={styles.damageValue} id="combo-info-result-dmg">
+            {props.accumulatedDamage}
+          </span>
+          <label class={styles.damageLabel} for="combo-info-result-dmg">
+            Damage
+          </label>
+        </div>
+        <button type="button" class={styles.xBtn} id="clear-all-accumulated-combos" onClick={props.onClickClearAll}>
+          <SvgX />
+          <label class={styles.xBtnLabel} for="clear-all-accumulated-combos">
+            Clear All
+          </label>
+        </button>
+      </div>
+    </div>
+  );
+};
+

--- a/src/Calculator/Calculator.module.css
+++ b/src/Calculator/Calculator.module.css
@@ -1,12 +1,41 @@
 .container {
+  display: grid;
+  grid-template-columns: minmax(0, 650px) auto;
+  margin: 0 auto;
+}
+
+.left {
+  max-width: 100vw;
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: 1rem 0.5rem 0 0.5rem;
   height: 100%;
   width: 100%;
-  max-width: 650px;
   margin: 0 auto;
+}
+
+.right {
+  height: calc(100vh - 50px);
+  overflow-y: hidden;
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0 0.5rem;
+}
+
+.rightInnerCombos {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+  margin-top: 1rem;
+}
+
+.rightInnerTotal {
+  margin: 1rem 0;
 }
 
 .additionalGagMultiplier {
@@ -33,5 +62,14 @@ html[data-theme="dark"] .additionalGagMultiplier {
   margin: auto 1rem 0.5rem 1rem;
   padding: 1rem 0;
   font-size: 0.9rem;
+}
+
+@media (max-width: 570px) {
+  .container {
+    grid-template-columns: 1fr;
+  }
+  .right {
+    height: unset;
+  }
 }
 

--- a/src/Calculator/Calculator.tsx
+++ b/src/Calculator/Calculator.tsx
@@ -63,7 +63,7 @@ export const Calculator = () => {
       }
       case OnClickSelectedGagAction.Copy: {
         setCombo(c => {
-          c.gags.push(Gag.fromGag(data.gag));
+          c.gags.push(data.gag.clone());
           return c;
         });
         break;

--- a/src/Calculator/Calculator.tsx
+++ b/src/Calculator/Calculator.tsx
@@ -1,7 +1,7 @@
-import { Show } from 'solid-js';
+import { Show, For } from 'solid-js';
 import { useStore } from '../store.instance';
 import * as util from '../util';
-import { cogHp } from '../constants';
+import { cogHp, additionalGagMultipliers } from '../constants';
 import {
   OnClickSelectedGagAction,
   OnClickGridGag,
@@ -16,6 +16,8 @@ import { GagGrid } from './GagGrid';
 import { CogsHp } from './CogsHp';
 import { CogDestroyed } from './CogDestroyed';
 import { SelectedGags } from './SelectedGags';
+import { AccumulatedDamageCombo } from './AccumulatedDamageCombo';
+import { AccumulatedDamageDisplay } from './AccumulatedDamageDisplay';
 import styles from './Calculator.module.css';
 
 export const Calculator = () => {
@@ -112,76 +114,101 @@ export const Calculator = () => {
 
   return (
     <div class={styles.container}>
-      <GagGrid onClickGag={onClickGridGag} />
+      <div class={styles.left}>
+        <GagGrid onClickGag={onClickGridGag} />
 
-      <CogsHp comboDamage={comboDamage()} />
+        <CogsHp comboDamage={comboDamage()} />
 
-      <label for="additional-gag-multiplier">Additional Gag Multiplier:</label>
-      <select
-        id="additional-gag-multiplier"
-        class={styles.additionalGagMultiplier}
-        name="additional gag multiplier"
-        value={additionalGagMultiplier().toString()}
-        onChange={e => store.setAdditionalGagMultiplier(Number(e.target.value))}
-      >
-        <option value="0">None</option>
-        <option value="-0.1">-10% (1-star FO Market Research)</option>
-        <option value="-0.15">-15% (2-star FO Market Research)</option>
-        <option value="-0.2">-20% (3-star FO Market Research)</option>
-        <option value="-0.25">-25% (Factory Foreman Cogs / 4-star FO Market Research)</option>
-        <option value="0.2">+20% (Club President 1 Cog Defeated)</option>
-        <option value="0.25">+25% (Coin Bull Market)</option>
-        <option value="0.4">+40% (Club President 2 Cogs Defeated)</option>
-        <option value="0.5">+50% (Fired Up / Bullion Bull Market)</option>
-        <option value="0.6">+60% (Club President 3 Cogs Defeated)</option>
-      </select>
-
-      <Show when={cogLvlDestroyed()}>
-        {cogLvl => <CogDestroyed cogLvl={cogLvl()} comboDamage={comboDamage()} />}
-      </Show>
-
-      <Show when={combo().gags.length > 0}>
-        <button
-          class={styles.clearGagsBtn}
-          onClick={onClickClearGags}
+        <label for="additional-gag-multiplier">Additional Gag Multiplier:</label>
+        <select
+          id="additional-gag-multiplier"
+          class={styles.additionalGagMultiplier}
+          name="additional gag multiplier"
+          value={additionalGagMultiplier().toString()}
+          onChange={e => store.setAdditionalGagMultiplier(Number(e.target.value))}
         >
-          Clear all gags ({combo().gags.length})
-        </button>
-      </Show>
+          {Object.entries(additionalGagMultipliers).map(([value, desc]) => (
+            <option value={value}>{desc}</option>
+          ))}
+        </select>
 
-      <SelectedGags
-        combo={combo()}
-        additionalGagMultiplier={additionalGagMultiplier()}
-        onClickOrgToggle={onClickOrgToggle}
-        onClickGag={onClickSelectedGag}
-        onClickGagLvlMod={onClickSelectedGagLvlMod}
-        onClickClearGags={onClickClearGags}
-      />
+        <Show when={cogLvlDestroyed()}>
+          {cogLvl => <CogDestroyed cogLvl={cogLvl()} comboDamage={comboDamage()} />}
+        </Show>
 
-      <div class={styles.howTo}>
-        <ul>
-          <li>Click to select a gag</li>
-          <li>Right-click to select an organic gag</li>
-          <li>
-            <span>Or click the organic icon&nbsp;</span>
-            <span style={{ position: 'relative', 'padding-right': '1.1rem' }}>
-              <img
-                style={{ position: 'absolute', top: 0, left: 0, width: '1.1rem', height: '1.1rem' }}
-                src={util.getResourceUrl('Organic.png')}
-              />
-            </span>
-            <span>&nbsp;of a selected gag to toggle organic</span>
-          </li>
-          <li>Click a selected gag to deselect it</li>
-          <li>Click a selected gag's up/down buttons to level it up/down</li>
-          <li>Right-click a selected gag to duplicate it</li>
-          <li>
-            Note about <i>Additional Gag Multiplier</i>:<br/>
-            If the calculations seem odd, that's because they are.<br/>
-            <a href="https://github.com/zzzachzzz/toontown-combos/issues/34#issuecomment-2282841602">Learn more here</a>
-          </li>
-        </ul>
+        <Show when={combo().gags.length > 0}>
+          <div style={{ 'display': 'flex', 'justify-content': 'space-between', 'width': '100%' }}>
+            <button
+              class={styles.clearGagsBtn}
+              onClick={onClickClearGags}
+            >
+              Clear all gags ({combo().gags.length})
+            </button>
+
+            <button
+              class={styles.clearGagsBtn}
+              onClick={() => store.pushAccumulatedDamageCombo()}
+            >
+              Add Combo to Total
+            </button>
+          </div>
+        </Show>
+
+        <SelectedGags
+          combo={combo()}
+          additionalGagMultiplier={additionalGagMultiplier()}
+          onClickOrgToggle={onClickOrgToggle}
+          onClickGag={onClickSelectedGag}
+          onClickGagLvlMod={onClickSelectedGagLvlMod}
+          onClickClearGags={onClickClearGags}
+        />
+
+        <div class={styles.howTo}>
+          <ul>
+            <li>Click to select a gag</li>
+            <li>Right-click to select an organic gag</li>
+            <li>
+              <span>Or click the organic icon&nbsp;</span>
+              <span style={{ position: 'relative', 'padding-right': '1.1rem' }}>
+                <img
+                  style={{ position: 'absolute', top: 0, left: 0, width: '1.1rem', height: '1.1rem' }}
+                  src={util.getResourceUrl('Organic.png')}
+                />
+              </span>
+              <span>&nbsp;of a selected gag to toggle organic</span>
+            </li>
+            <li>Click a selected gag to deselect it</li>
+            <li>Click a selected gag's up/down buttons to level it up/down</li>
+            <li>Right-click a selected gag to duplicate it</li>
+            <li>
+              Note about <i>Additional Gag Multiplier</i>:<br/>
+              If the calculations seem odd, that's because they are.<br/>
+              <a href="https://github.com/zzzachzzz/toontown-combos/issues/34#issuecomment-2282841602">Learn more here</a>
+            </li>
+          </ul>
+        </div>
       </div>
+       <Show when={store.getAccumulatedDamageCombos().length > 0}>
+         <div class={styles.right}>
+           <div class={styles.rightInnerCombos}>
+             <For each={store.getAccumulatedDamageCombos()}>
+               {({ combo, additionalGagMultiplier }, index) => (
+                 <AccumulatedDamageCombo
+                   combo={combo}
+                   additionalGagMultiplier={additionalGagMultiplier}
+                   onClickRemove={() => store.removeAccumulatedDamageCombo(index())}
+                 />
+               )}
+             </For>
+           </div>
+           <div class={styles.rightInnerTotal}>
+             <AccumulatedDamageDisplay
+               accumulatedDamage={store.getAccumulatedCombosDamage()}
+               onClickClearAll={store.clearAccumulatedDamageCombos}
+             />
+           </div>
+         </div>
+       </Show>
     </div>
   );
 };

--- a/src/Calculator/SvgX.tsx
+++ b/src/Calculator/SvgX.tsx
@@ -1,0 +1,17 @@
+export const SvgX = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="32"
+    height="32"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="var(--color-fg)"
+    stroke-width="1"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path d="M18 6l-12 12" />
+    <path d="M6 6l12 12" />
+  </svg>
+);
+

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -161,3 +161,16 @@ export const sosToonGags: Record<
   },
 };
 
+export const additionalGagMultipliers: Record<number, string> = {
+  [0]:      'None',
+  [-0.1]:   '-10% (1-star FO Market Research)',
+  [-0.15]:  '-15% (2-star FO Market Research)',
+  [-0.2]:   '-20% (3-star FO Market Research)',
+  [-0.25]:  '-25% (Factory Foreman Cogs / 4-star FO Market Research)',
+  [0.2]:    '+20% (Club President 1 Cog Defeated)',
+  [0.25]:   '+25% (Coin Bull Market)',
+  [0.4]:    '+40% (Club President 2 Cogs Defeated)',
+  [0.5]:    '+50% (Fired Up / Bullion Bull Market)',
+  [0.6]:    '+60% (Club President 3 Cogs Defeated)',
+};
+

--- a/src/gags.ts
+++ b/src/gags.ts
@@ -38,10 +38,9 @@ export class Gag {
     this.isOrg = isOrg;
   }
 
-  /** Create new `Combo` instance, copied from another instance */
-  static fromGag(gag: Gag): Gag {
+  clone(): Gag {
     return new Gag({
-      track: gag.track, lvl: gag.lvl, isOrg: gag.isOrg
+      track: this.track, lvl: this.lvl, isOrg: this.isOrg
     });
   }
 
@@ -122,7 +121,11 @@ export class Gag {
   }
 }
 
+type SosToonGagTrack = keyof typeof sosToonGags;
+
 export class SosToonGag extends Gag {
+  declare track: SosToonGagTrack;
+
   constructor(sosToon: SosToons) {
     super({
       track: SosToonGag.getTrackFromSosToon(sosToon),
@@ -132,14 +135,18 @@ export class SosToonGag extends Gag {
   }
 
   static fromTrackAndLvl(
-    track: GagTracks.trap | GagTracks.sound | GagTracks.drop,
+    track: SosToonGagTrack,
     lvl: number,
   ): SosToonGag {
     const { sosToon } = sosToonGags[track][lvl];
     return new SosToonGag(sosToon);
   }
 
-  private static getTrackFromSosToon(sosToon: SosToons): GagTrack {
+  override clone(): SosToonGag {
+    return new SosToonGag(this.sosToon);
+  }
+
+  private static getTrackFromSosToon(sosToon: SosToons): SosToonGagTrack {
     switch (sosToon) {
       case SosToons.ClerkWill:
       case SosToons.ClerkPenny:
@@ -178,15 +185,15 @@ export class SosToonGag extends Gag {
   }
 
   get sosToon(): SosToons {
-    return sosToonGags[this.track as GagTracks.trap | GagTracks.sound | GagTracks.drop][this.lvl].sosToon;
+    return sosToonGags[this.track][this.lvl].sosToon;
   }
 
   override get name(): string {
-    return sosToonGags[this.track as GagTracks.trap | GagTracks.sound | GagTracks.drop][this.lvl].name;
+    return sosToonGags[this.track][this.lvl].name;
   }
 
   override get damage(): number {
-    return sosToonGags[this.track as GagTracks.trap | GagTracks.sound | GagTracks.drop][this.lvl].damage;
+    return sosToonGags[this.track][this.lvl].damage;
   }
 }
 
@@ -200,9 +207,9 @@ export class Combo {
   }
 
   /** Create new `Combo` instance, copied from another instance */
-  static fromCombo(combo: Combo): Combo {
+  clone(): Combo {
     return new Combo({
-      gags: combo.gags.map(g => Gag.fromGag(g)),
+      gags: this.gags.map(g => g.clone()),
     });
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,6 +13,10 @@ export type State = {
   hideLvl15UpCogs: boolean;
   level4UpGagsOnly: boolean;
   theme: 'light' | 'dark';
+  accumulatedDamageCombos: Array<{
+    combo: Combo;
+    additionalGagMultiplier: number;
+  }>;
 };
 
 type CreateStoreArgs = {
@@ -30,6 +34,7 @@ export const createStore = ({
     hideLvl15UpCogs: false,
     level4UpGagsOnly: false,
     theme: 'light',
+    accumulatedDamageCombos: [],
     ...initialState,
   });
 
@@ -51,6 +56,34 @@ export const createStore = ({
 
     setAdditionalGagMultiplier = (value: State['additionalGagMultiplier']) =>
       setState('additionalGagMultiplier', value);
+
+    pushAccumulatedDamageCombo = () => {
+      const combo = this.getCalculatorCombo().clone();
+      const { additionalGagMultiplier } = state;
+      setState(
+        'accumulatedDamageCombos',
+        state.accumulatedDamageCombos.length,
+        { combo, additionalGagMultiplier }
+      );
+    };
+
+    removeAccumulatedDamageCombo = (index: number) => {
+      setState(
+        'accumulatedDamageCombos',
+        arr => [...arr.slice(0, index), ...arr.slice(index + 1)]
+      );
+    };
+
+    clearAccumulatedDamageCombos = () => {
+      setState('accumulatedDamageCombos', []);
+    };
+
+    getAccumulatedDamageCombos = () => state.accumulatedDamageCombos;
+
+    getAccumulatedCombosDamage = createMemo((): number => state.accumulatedDamageCombos.reduce(
+      (acc, { combo, additionalGagMultiplier }) => acc + combo.damage({ additionalGagMultiplier }),
+      0
+    ));
 
     getIsLured = () => state.isLured;
 


### PR DESCRIPTION
- Multi-round accumulated combos damage tracking <https://github.com/zzzachzzz/toontown-combos/issues/44>

- `fromGag` / `fromCombo` -> `clone` methods, fix `track` type on `SosToonGag`

@mrand 

<img width="1332" height="911" alt="accumulated-combos-damage" src="https://github.com/user-attachments/assets/52d0397d-07a9-4c9b-92d6-d3eca1164dc3" />
