### PR TITLE
Massive `findCombo` algorithm refactor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.snap linguist-generated
+

--- a/src/Calculator/AccumulatedDamageCombo.tsx
+++ b/src/Calculator/AccumulatedDamageCombo.tsx
@@ -1,7 +1,7 @@
 import { JSX, Show, For } from 'solid-js';
 import * as util from '../util';
 import { Combo, SosToonGag } from '../gags';
-import { additionalGagMultipliers } from '../constants';
+import { ADDITIONAL_GAG_MULTIPLIERS } from '../constants';
 import { SvgX } from './SvgX';
 import stylesSelectedGags from './SelectedGags.module.css';
 import stylesAccumulatedDamageCombo from './AccumulatedDamageCombo.module.css';
@@ -18,7 +18,7 @@ export const AccumulatedDamageCombo = (props: Props) => {
   return (
     <div class={styles.container}>
       <Show when={props.additionalGagMultiplier !== 0}>
-        <div style={{ 'font-size': '0.8rem' }}>{additionalGagMultipliers[props.additionalGagMultiplier]}</div>
+        <div style={{ 'font-size': '0.8rem' }}>{ADDITIONAL_GAG_MULTIPLIERS[props.additionalGagMultiplier]}</div>
         <hr style={{ border: 'none', 'border-top': `2px solid var(--black)` }} />
       </Show>
       <div class={styles.flexContainer}>

--- a/src/Calculator/Calculator.tsx
+++ b/src/Calculator/Calculator.tsx
@@ -1,7 +1,7 @@
 import { Show, For } from 'solid-js';
 import { useStore } from '../store.instance';
 import * as util from '../util';
-import { cogHp, additionalGagMultipliers } from '../constants';
+import { COG_HP, ADDITIONAL_GAG_MULTIPLIERS } from '../constants';
 import {
   OnClickSelectedGagAction,
   OnClickGridGag,
@@ -105,7 +105,7 @@ export const Calculator = () => {
   };
 
   const cogLvlDestroyed = (): number | null => {
-    for (const [cogLvl, _cogHp] of Object.entries(cogHp).reverse()) {
+    for (const [cogLvl, _cogHp] of Object.entries(COG_HP).reverse()) {
       if (comboDamage() >= _cogHp)
         return Number(cogLvl);
     }
@@ -127,7 +127,7 @@ export const Calculator = () => {
           value={additionalGagMultiplier().toString()}
           onChange={e => store.setAdditionalGagMultiplier(Number(e.target.value))}
         >
-          {Object.entries(additionalGagMultipliers).map(([value, desc]) => (
+          {Object.entries(ADDITIONAL_GAG_MULTIPLIERS).map(([value, desc]) => (
             <option value={value}>{desc}</option>
           ))}
         </select>

--- a/src/Calculator/CogDestroyed.tsx
+++ b/src/Calculator/CogDestroyed.tsx
@@ -1,5 +1,5 @@
 import * as util from '../util';
-import { cogHp } from '../constants';
+import { COG_HP } from '../constants';
 import styles from './CogDestroyed.module.css';
 
 type Props = {
@@ -8,7 +8,7 @@ type Props = {
 };
 
 export const CogDestroyed = (props: Props) => {
-  const remaining = () => cogHp[props.cogLvl] - props.comboDamage;
+  const remaining = () => COG_HP[props.cogLvl] - props.comboDamage;
 
   return (
     <div class={styles.container}>
@@ -24,7 +24,7 @@ export const CogDestroyed = (props: Props) => {
           <tr>
             <td class={styles.cell}>
               <div class={styles.cogLvl}>Level: {props.cogLvl}</div>
-              <div class={styles.cogHp}>HP: {cogHp[props.cogLvl]}</div>
+              <div class={styles.cogHp}>HP: {COG_HP[props.cogLvl]}</div>
               <div class={styles.cogsHpRemaining}>
                 Remaining: {remaining()}
               </div>

--- a/src/Calculator/CogsHp.tsx
+++ b/src/Calculator/CogsHp.tsx
@@ -1,6 +1,6 @@
 import { For } from 'solid-js';
 import * as util from '../util';
-import { cogHp } from '../constants';
+import { COG_HP } from '../constants';
 import styles from './CogsHp.module.css';
 
 type Props = {
@@ -17,7 +17,7 @@ export const CogsHp = (props: Props) => {
               <tr>
                 <For each={range}>
                   {cogLvl => {
-                    const remaining = () => cogHp[cogLvl] - props.comboDamage;
+                    const remaining = () => COG_HP[cogLvl] - props.comboDamage;
 
                     const tdStyle = () => {
                       if (props.comboDamage === 0)
@@ -30,7 +30,7 @@ export const CogsHp = (props: Props) => {
                     return (
                       <td class={styles.cell} style={tdStyle()}>
                         <div class={styles.cogLvl}>{cogLvl}</div>
-                        <div class={styles.cogHp}>{cogHp[cogLvl]}</div>
+                        <div class={styles.cogHp}>{COG_HP[cogLvl]}</div>
                         <div class={styles.cogHpRemaining}>
                           {props.comboDamage === 0 ? '-' : remaining()}
                         </div>

--- a/src/Calculator/GagGrid.tsx
+++ b/src/Calculator/GagGrid.tsx
@@ -1,6 +1,6 @@
 import { For } from 'solid-js';
 import * as util from '../util';
-import { gagTracksArr, gagTrackDisplayName, SosToons } from '../constants';
+import { GagTracks, GAG_TRACK_DISPLAY_NAME, SosToons } from '../constants';
 import { OnClickGridGag } from './types';
 import styles from './GagGrid.module.css';
 
@@ -11,11 +11,11 @@ type Props = {
 export const GagGrid = (props: Props) => {
   return (
     <div class={styles.container}>
-      <For each={gagTracksArr}>
+      <For each={Object.values(GagTracks)}>
         {track => {
           return (
             <div class={`${styles.row} no-drag`} style={{ background: `var(--${track})` }}>
-              <div class={styles.gagTrackLabel}>{gagTrackDisplayName[track]}</div>
+              <div class={styles.gagTrackLabel}>{GAG_TRACK_DISPLAY_NAME[track]}</div>
               <For each={[...util.range(1, 7)]} >
                 {lvl => {
                   return (

--- a/src/Calculator/SelectedGags.tsx
+++ b/src/Calculator/SelectedGags.tsx
@@ -27,15 +27,15 @@ type Props = {
 export const SelectedGags = (props: Props) => {
   return (
     <div class={styles.container}>
-      <For each={props.combo.gagsGroupedByTrack()}>
-        {gagGroup => {
+      <For each={Object.entries(props.combo.gagsGroupedByTrack())}>
+        {([track, gagGroup]) => {
           // Multipliers will be the same for the gags of a given track in the combo
           const multipliers = createMemo(() => gagGroup[0].multipliers(props.combo));
 
           return (
-            <div class={styles.selectedGagGroup} style={{ border: `4px solid var(--${gagGroup[0].track})` }}>
+            <div class={styles.selectedGagGroup} style={{ border: `4px solid var(--${track})` }}>
               <div style={{ display: 'flex', 'flex-direction': 'column', gap: '0.5rem' }}>
-                <Show when={gagGroup[0].track === GagTracks.trap && gagGroup.length >= 2}>
+                <Show when={track === GagTracks.trap && gagGroup.length >= 2}>
                   <span class={styles.multiTrapWarning}>
                     Multiple trap present in combo, damage negated
                   </span>

--- a/src/ComboGrid/CogLvlCell.tsx
+++ b/src/ComboGrid/CogLvlCell.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '../store.instance';
-import { cogHp as cogHpLookup } from '../constants';
+import { COG_HP as cogHpLookup } from '../constants';
 import { getCogIconUrl } from '../util';
 import styles from './CogLvlCell.module.css';
 

--- a/src/ComboGrid/Combo.tsx
+++ b/src/ComboGrid/Combo.tsx
@@ -1,32 +1,33 @@
-import { For, Show } from 'solid-js';
-import type { FindComboResult } from '../gags';
+import { For } from 'solid-js';
+import type { Combo as ComboType } from '../gags';
 import { getGagIconUrl } from '../util';
 import styles from './Combo.module.css';
 
 type Props = {
-  combo: FindComboResult;
+  combo: ComboType;
+  isLured: boolean;
 };
 
 export const Combo = (props: Props) => {
   return (
-    <Show when={props.combo.damageKillsCog()}>
-      <div class={styles.combo}>
-        <span class={styles.dmg}>{props.combo.damage()}</span>
-        <div class={styles.gags}>
-          <For each={props.combo.combo.gags}>
-            {gag => (
-              <div
-                class={styles.gagIconContainer}
-                style={{ background: gag.isOrg ? `var(--${gag.track})` : 'unset' }}
-              >
-                <img class={styles.gagIcon} src={getGagIconUrl({ track: gag.track, lvl: gag.lvl })} />
-                {gag.isOrg && <span class={styles.orgText}>Org</span>}
-              </div>
-            )}
-          </For>
-        </div>
+    <div class={styles.combo}>
+      <span class={styles.dmg}>
+        {props.combo.damage({ isLured: props.isLured })}
+      </span>
+      <div class={styles.gags}>
+        <For each={props.combo.gags}>
+          {gag => (
+            <div
+              class={styles.gagIconContainer}
+              style={{ background: gag.isOrg ? `var(--${gag.track})` : 'unset' }}
+            >
+              <img class={styles.gagIcon} src={getGagIconUrl({ track: gag.track, lvl: gag.lvl })} />
+              {gag.isOrg && <span class={styles.orgText}>Org</span>}
+            </div>
+          )}
+        </For>
       </div>
-    </Show>
+    </div>
   );
 };
 

--- a/src/ComboGrid/ComboGrid.tsx
+++ b/src/ComboGrid/ComboGrid.tsx
@@ -63,7 +63,11 @@ export const ComboGrid = () => {
               {comboBatch => (
                 <div>
                   <For each={comboBatch}>
-                    {combo => <Combo combo={combo} />}
+                    {maybeCombo => (
+                      <Show when={maybeCombo}>
+                        {combo => <Combo combo={combo()} isLured={store.getIsLured()} />}
+                      </Show>
+                    )}
                   </For>
                 </div>
               )}

--- a/src/ComboGrid/OrganicSelectionToonColumn.tsx
+++ b/src/ComboGrid/OrganicSelectionToonColumn.tsx
@@ -1,6 +1,6 @@
 import { For, Show } from 'solid-js';
 import { useStore } from '../store.instance';
-import { gagTracksArr, gagTrackDisplayName, GagTrack } from '../constants';
+import { GagTracks, GAG_TRACK_DISPLAY_NAME, GagTrack } from '../constants';
 import { getGagIconUrl } from '../util';
 import * as storage from '../local-storage';
 import styles from './OrganicSelectionToonColumn.module.css';
@@ -23,7 +23,7 @@ export const OrganicSelectionToonColumn = (props: Props) => {
   return (
     <ul class={styles.column} role="listbox">
       {store.getShowOrgView() ? (
-        <For each={gagTracksArr}>
+        <For each={Object.values(GagTracks)}>
           {gagTrack => (
             <GagTrackListItem
               toonIdx={props.toonIdx}
@@ -74,7 +74,7 @@ const GagTrackListItem = (props: GagTrackListItemProps) => {
           <div class={styles.imgContainer}>
             <img src={getGagIconUrl({ track: props.gagTrack!, lvl: 1 })} />
           </div>
-          <span>{gagTrackDisplayName[props.gagTrack!]}</span>
+          <span>{GAG_TRACK_DISPLAY_NAME[props.gagTrack!]}</span>
         </button>
       </Show>
     </li>

--- a/src/__snapshots__/gags.test.ts.snap
+++ b/src/__snapshots__/gags.test.ts.snap
@@ -1,1273 +1,15711 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`FindComboResult > inputKey & outputKey > generates the expected input key and output key 1`] = `
-{
-  "inputKey": {
-    "cog": {
-      "isLured": true,
-      "lvl": 11,
-    },
-    "gags": {
-      "sound": 1,
-      "squirt": 2,
-      "throw": 1,
-    },
-    "organicGags": {},
-  },
-  "outputKey": {
-    "dmg": 0,
-    "gags": [],
-  },
-}
-`;
-
-exports[`FindComboResult > inputKey & outputKey > generates the expected input key and output key 2`] = `
-{
-  "inputKey": {
-    "cog": {
-      "isLured": false,
-      "lvl": 11,
-    },
-    "gags": {
-      "drop": 2,
-      "squirt": 2,
-    },
-    "organicGags": {
-      "drop": 1,
-    },
-  },
-  "outputKey": {
-    "dmg": 0,
-    "gags": [],
-  },
-}
-`;
-
-exports[`findCombo > combos match the snapshot for args {"maxCogLvl":12,"organicGags":{},"isLured":false} 1`] = `
+exports[`findCombo > matches snapshot for all 2sound2drop & 3sound1drop permutations 1`] = `
 [
-  FindComboResult {
-    "cog": Cog([Lvl 12] [Hp 196]),
-    "damage": 200,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 12] [Hp 196]),
-    "damage": 228,
-    "gags": [
-      Gag(Opera Singer [Lvl 7] [Dmg 90]),
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 12] [Hp 196]),
-    "damage": 216,
-    "gags": [
-      Gag(Opera Singer [Lvl 7] [Dmg 90]),
-      Gag(Opera Singer [Lvl 7] [Dmg 90]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 12] [Hp 196]),
-    "damage": 0,
-    "gags": [
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 12] [Hp 196]),
-    "damage": 197,
-    "gags": [
-      Gag(Birthday Cake [Lvl 6] [Dmg 100]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 12] [Hp 196]),
-    "damage": 201,
-    "gags": [
-      Gag(Birthday Cake [Lvl 6] [Dmg 100]),
-      Gag(Whole Cream Pie [Lvl 5] [Dmg 40]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 12] [Hp 196]),
-    "damage": 240,
-    "gags": [
-      Gag(Birthday Cake [Lvl 6] [Dmg 100]),
-      Gag(Birthday Cake [Lvl 6] [Dmg 100]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 12] [Hp 196]),
-    "damage": 0,
-    "gags": [
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 12] [Hp 196]),
-    "damage": 204,
-    "gags": [
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 12] [Hp 196]),
-    "damage": 197,
-    "gags": [
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 12] [Hp 196]),
-    "damage": 222,
-    "gags": [
-      Gag(Geyser [Lvl 7] [Dmg 105]),
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 12] [Hp 196]),
-    "damage": 0,
-    "gags": [
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 11] [Hp 156]),
-    "damage": 159,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 11] [Hp 156]),
-    "damage": 180,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 11] [Hp 156]),
-    "damage": 168,
-    "gags": [
-      Gag(Opera Singer [Lvl 7] [Dmg 90]),
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 11] [Hp 156]),
-    "damage": 0,
-    "gags": [
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 11] [Hp 156]),
-    "damage": 161,
-    "gags": [
-      Gag(Whole Cream Pie [Lvl 5] [Dmg 40]),
-      Gag(Whole Cream Pie [Lvl 5] [Dmg 40]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 11] [Hp 156]),
-    "damage": 161,
-    "gags": [
-      Gag(Birthday Cake [Lvl 6] [Dmg 100]),
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 11] [Hp 156]),
-    "damage": 168,
-    "gags": [
-      Gag(Birthday Cake [Lvl 6] [Dmg 100]),
-      Gag(Whole Cream Pie [Lvl 5] [Dmg 40]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 11] [Hp 156]),
-    "damage": 0,
-    "gags": [
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 11] [Hp 156]),
-    "damage": 156,
-    "gags": [
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 11] [Hp 156]),
-    "damage": 158,
-    "gags": [
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 11] [Hp 156]),
-    "damage": 192,
-    "gags": [
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 11] [Hp 156]),
-    "damage": 0,
-    "gags": [
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 10] [Hp 132]),
-    "damage": 136,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 10] [Hp 132]),
-    "damage": 134,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 10] [Hp 132]),
-    "damage": 134,
-    "gags": [
-      Gag(Opera Singer [Lvl 7] [Dmg 90]),
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 10] [Hp 132]),
-    "damage": 0,
-    "gags": [
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 10] [Hp 132]),
-    "damage": 134,
-    "gags": [
-      Gag(Whole Cream Pie [Lvl 5] [Dmg 40]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 10] [Hp 132]),
-    "damage": 144,
-    "gags": [
-      Gag(Whole Cream Pie [Lvl 5] [Dmg 40]),
-      Gag(Whole Cream Pie [Lvl 5] [Dmg 40]),
-      Gag(Whole Cream Pie [Lvl 5] [Dmg 40]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 10] [Hp 132]),
-    "damage": 132,
-    "gags": [
-      Gag(Birthday Cake [Lvl 6] [Dmg 100]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 10] [Hp 132]),
-    "damage": 0,
-    "gags": [
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 10] [Hp 132]),
-    "damage": 134,
-    "gags": [
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 10] [Hp 132]),
-    "damage": 136,
-    "gags": [
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 10] [Hp 132]),
-    "damage": 132,
-    "gags": [
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 10] [Hp 132]),
-    "damage": 0,
-    "gags": [
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 9] [Hp 110]),
-    "damage": 112,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 9] [Hp 110]),
-    "damage": 111,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 9] [Hp 110]),
-    "damage": 120,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 9] [Hp 110]),
-    "damage": 0,
-    "gags": [
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 9] [Hp 110]),
-    "damage": 110,
-    "gags": [
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 9] [Hp 110]),
-    "damage": 113,
-    "gags": [
-      Gag(Whole Cream Pie [Lvl 5] [Dmg 40]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 9] [Hp 110]),
-    "damage": 128,
-    "gags": [
-      Gag(Birthday Cake [Lvl 6] [Dmg 100]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 9] [Hp 110]),
-    "damage": 120,
-    "gags": [
-      Gag(Wedding Cake [Lvl 7] [Dmg 120]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 9] [Hp 110]),
-    "damage": 112,
-    "gags": [
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 9] [Hp 110]),
-    "damage": 111,
-    "gags": [
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 9] [Hp 110]),
-    "damage": 111,
-    "gags": [
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 9] [Hp 110]),
-    "damage": 0,
-    "gags": [
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 8] [Hp 90]),
-    "damage": 95,
-    "gags": [
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 8] [Hp 90]),
-    "damage": 93,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 8] [Hp 90]),
-    "damage": 120,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 8] [Hp 90]),
-    "damage": 90,
-    "gags": [
-      Gag(Opera Singer [Lvl 7] [Dmg 90]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 8] [Hp 90]),
-    "damage": 94,
-    "gags": [
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 8] [Hp 90]),
-    "damage": 98,
-    "gags": [
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 8] [Hp 90]),
-    "damage": 96,
-    "gags": [
-      Gag(Whole Cream Pie [Lvl 5] [Dmg 40]),
-      Gag(Whole Cream Pie [Lvl 5] [Dmg 40]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 8] [Hp 90]),
-    "damage": 100,
-    "gags": [
-      Gag(Birthday Cake [Lvl 6] [Dmg 100]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 8] [Hp 90]),
-    "damage": 90,
-    "gags": [
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 8] [Hp 90]),
-    "damage": 98,
-    "gags": [
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 8] [Hp 90]),
-    "damage": 101,
-    "gags": [
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 8] [Hp 90]),
-    "damage": 105,
-    "gags": [
-      Gag(Geyser [Lvl 7] [Dmg 105]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 7] [Hp 72]),
-    "damage": 77,
-    "gags": [
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 7] [Hp 72]),
-    "damage": 76,
-    "gags": [
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 7] [Hp 72]),
-    "damage": 74,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 7] [Hp 72]),
-    "damage": 90,
-    "gags": [
-      Gag(Opera Singer [Lvl 7] [Dmg 90]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 7] [Hp 72]),
-    "damage": 74,
-    "gags": [
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 7] [Hp 72]),
-    "damage": 74,
-    "gags": [
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 7] [Hp 72]),
-    "damage": 81,
-    "gags": [
-      Gag(Whole Cream Pie [Lvl 5] [Dmg 40]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 7] [Hp 72]),
-    "damage": 100,
-    "gags": [
-      Gag(Birthday Cake [Lvl 6] [Dmg 100]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 7] [Hp 72]),
-    "damage": 75,
-    "gags": [
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 7] [Hp 72]),
-    "damage": 76,
-    "gags": [
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 7] [Hp 72]),
-    "damage": 72,
-    "gags": [
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 7] [Hp 72]),
-    "damage": 80,
-    "gags": [
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 6] [Hp 56]),
-    "damage": 59,
-    "gags": [
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 6] [Hp 56]),
-    "damage": 58,
-    "gags": [
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 6] [Hp 56]),
-    "damage": 65,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 6] [Hp 56]),
-    "damage": 90,
-    "gags": [
-      Gag(Opera Singer [Lvl 7] [Dmg 90]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 6] [Hp 56]),
-    "damage": 57,
-    "gags": [
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 6] [Hp 56]),
-    "damage": 62,
-    "gags": [
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 6] [Hp 56]),
-    "damage": 65,
-    "gags": [
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 6] [Hp 56]),
-    "damage": 100,
-    "gags": [
-      Gag(Birthday Cake [Lvl 6] [Dmg 100]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 6] [Hp 56]),
-    "damage": 58,
-    "gags": [
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 6] [Hp 56]),
-    "damage": 56,
-    "gags": [
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 6] [Hp 56]),
-    "damage": 62,
-    "gags": [
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 6] [Hp 56]),
-    "damage": 80,
-    "gags": [
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 5] [Hp 42]),
-    "damage": 44,
-    "gags": [
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-      Gag(Whistle [Lvl 2] [Dmg 7]),
-      Gag(Whistle [Lvl 2] [Dmg 7]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 5] [Hp 42]),
-    "damage": 46,
-    "gags": [
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 5] [Hp 42]),
-    "damage": 45,
-    "gags": [
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 5] [Hp 42]),
-    "damage": 50,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 5] [Hp 42]),
-    "damage": 44,
-    "gags": [
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 5] [Hp 42]),
-    "damage": 45,
-    "gags": [
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 5] [Hp 42]),
-    "damage": 45,
-    "gags": [
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 5] [Hp 42]),
-    "damage": 100,
-    "gags": [
-      Gag(Birthday Cake [Lvl 6] [Dmg 100]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 5] [Hp 42]),
-    "damage": 44,
-    "gags": [
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 5] [Hp 42]),
-    "damage": 44,
-    "gags": [
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 5] [Hp 42]),
-    "damage": 51,
-    "gags": [
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 5] [Hp 42]),
-    "damage": 80,
-    "gags": [
-      Gag(Storm Cloud [Lvl 6] [Dmg 80]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 4] [Hp 30]),
-    "damage": 30,
-    "gags": [
-      Gag(Whistle [Lvl 2] [Dmg 7]),
-      Gag(Whistle [Lvl 2] [Dmg 7]),
-      Gag(Whistle [Lvl 2] [Dmg 7]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 4] [Hp 30]),
-    "damage": 30,
-    "gags": [
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-      Gag(Whistle [Lvl 2] [Dmg 7]),
-      Gag(Whistle [Lvl 2] [Dmg 7]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 4] [Hp 30]),
-    "damage": 33,
-    "gags": [
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 4] [Hp 30]),
-    "damage": 50,
-    "gags": [
-      Gag(Foghorn [Lvl 6] [Dmg 50]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 4] [Hp 30]),
-    "damage": 34,
-    "gags": [
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 4] [Hp 30]),
-    "damage": 32,
-    "gags": [
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 4] [Hp 30]),
-    "damage": 33,
-    "gags": [
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 4] [Hp 30]),
-    "damage": 40,
-    "gags": [
-      Gag(Whole Cream Pie [Lvl 5] [Dmg 40]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 4] [Hp 30]),
-    "damage": 34,
-    "gags": [
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 4] [Hp 30]),
-    "damage": 34,
-    "gags": [
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 4] [Hp 30]),
-    "damage": 30,
-    "gags": [
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 4] [Hp 30]),
-    "damage": 30,
-    "gags": [
-      Gag(Fire Hose [Lvl 5] [Dmg 30]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 3] [Hp 20]),
-    "damage": 20,
-    "gags": [
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 3] [Hp 20]),
-    "damage": 22,
-    "gags": [
-      Gag(Whistle [Lvl 2] [Dmg 7]),
-      Gag(Whistle [Lvl 2] [Dmg 7]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 3] [Hp 20]),
-    "damage": 22,
-    "gags": [
-      Gag(Bugle [Lvl 3] [Dmg 11]),
-      Gag(Whistle [Lvl 2] [Dmg 7]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 3] [Hp 20]),
-    "damage": 21,
-    "gags": [
-      Gag(Elephant Trunk [Lvl 5] [Dmg 21]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 3] [Hp 20]),
-    "damage": 22,
-    "gags": [
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 3] [Hp 20]),
-    "damage": 22,
-    "gags": [
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 3] [Hp 20]),
-    "damage": 20,
-    "gags": [
-      Gag(Fruit Pie Slice [Lvl 2] [Dmg 10]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 3] [Hp 20]),
-    "damage": 27,
-    "gags": [
-      Gag(Whole Fruit Pie [Lvl 4] [Dmg 27]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 3] [Hp 20]),
-    "damage": 20,
-    "gags": [
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 3] [Hp 20]),
-    "damage": 20,
-    "gags": [
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 3] [Hp 20]),
-    "damage": 20,
-    "gags": [
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 3] [Hp 20]),
-    "damage": 21,
-    "gags": [
-      Gag(Seltzer Bottle [Lvl 4] [Dmg 21]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 2] [Hp 12]),
-    "damage": 15,
-    "gags": [
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 2] [Hp 12]),
-    "damage": 15,
-    "gags": [
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 2] [Hp 12]),
-    "damage": 14,
-    "gags": [
-      Gag(Whistle [Lvl 2] [Dmg 7]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 2] [Hp 12]),
-    "damage": 16,
-    "gags": [
-      Gag(Aoogah [Lvl 4] [Dmg 16]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 2] [Hp 12]),
-    "damage": 15,
-    "gags": [
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      None,
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 2] [Hp 12]),
-    "damage": 15,
-    "gags": [
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 2] [Hp 12]),
-    "damage": 15,
-    "gags": [
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 2] [Hp 12]),
-    "damage": 17,
-    "gags": [
-      Gag(Cream Pie Slice [Lvl 3] [Dmg 17]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 2] [Hp 12]),
-    "damage": 15,
-    "gags": [
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 2] [Hp 12]),
-    "damage": 15,
-    "gags": [
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 2] [Hp 12]),
-    "damage": 15,
-    "gags": [
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 2] [Hp 12]),
-    "damage": 12,
-    "gags": [
-      Gag(Squirt Gun [Lvl 3] [Dmg 12]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 1] [Hp 6]),
-    "damage": 10,
-    "gags": [
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-      None,
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 1] [Hp 6]),
-    "damage": 10,
-    "gags": [
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 1] [Hp 6]),
-    "damage": 10,
-    "gags": [
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-      Gag(Bike Horn [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 1] [Hp 6]),
-    "damage": 7,
-    "gags": [
-      Gag(Whistle [Lvl 2] [Dmg 7]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 1] [Hp 6]),
-    "damage": 6,
-    "gags": [
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      None,
-      None,
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 1] [Hp 6]),
-    "damage": 6,
-    "gags": [
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      None,
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 1] [Hp 6]),
-    "damage": 6,
-    "gags": [
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 1] [Hp 6]),
-    "damage": 6,
-    "gags": [
-      Gag(Cupcake [Lvl 1] [Dmg 6]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 1] [Hp 6]),
-    "damage": 10,
-    "gags": [
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      None,
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 1] [Hp 6]),
-    "damage": 10,
-    "gags": [
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      None,
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 1] [Hp 6]),
-    "damage": 10,
-    "gags": [
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-      Gag(Squirting Flower [Lvl 1] [Dmg 4]),
-    ],
-  },
-  FindComboResult {
-    "cog": Cog([Lvl 1] [Hp 6]),
-    "damage": 8,
-    "gags": [
-      Gag(Glass of Water [Lvl 2] [Dmg 8]),
-    ],
+  {
+    "damage": "477/476",
+    "inputKey": "so_so_dr_dr_c20",
+    "outputKey": "so6_so2_dr6_dr6",
+  },
+  {
+    "damage": "477/476",
+    "inputKey": "so_so_Dr_dr_c20",
+    "outputKey": "so6_so2_dr6_dr6",
+  },
+  {
+    "damage": "477/476",
+    "inputKey": "so_so_Dr_Dr_c20",
+    "outputKey": "so6_so2_dr6_dr6",
+  },
+  {
+    "damage": "477/476",
+    "inputKey": "So_so_dr_dr_c20",
+    "outputKey": "so6_so2_dr6_dr6",
+  },
+  {
+    "damage": "477/476",
+    "inputKey": "So_so_Dr_dr_c20",
+    "outputKey": "so6_so2_dr6_dr6",
+  },
+  {
+    "damage": "477/476",
+    "inputKey": "So_so_Dr_Dr_c20",
+    "outputKey": "so6_so2_dr6_dr6",
+  },
+  {
+    "damage": "477/476",
+    "inputKey": "So_So_dr_dr_c20",
+    "outputKey": "so6_so2_dr6_dr6",
+  },
+  {
+    "damage": "477/476",
+    "inputKey": "So_So_Dr_dr_c20",
+    "outputKey": "so6_so2_dr6_dr6",
+  },
+  {
+    "damage": "477/476",
+    "inputKey": "So_So_Dr_Dr_c20",
+    "outputKey": "so6_so2_dr6_dr6",
+  },
+  {
+    "damage": "458/434",
+    "inputKey": "so_so_dr_dr_c19",
+    "outputKey": "so6_no_dr6_dr6",
+  },
+  {
+    "damage": "440/434",
+    "inputKey": "so_so_Dr_dr_c19",
+    "outputKey": "so6_so6_Dr6_dr5",
+  },
+  {
+    "damage": "453/434",
+    "inputKey": "so_so_Dr_Dr_c19",
+    "outputKey": "so6_so6_Dr6_Dr5",
+  },
+  {
+    "damage": "458/434",
+    "inputKey": "So_so_dr_dr_c19",
+    "outputKey": "so6_no_dr6_dr6",
+  },
+  {
+    "damage": "440/434",
+    "inputKey": "So_so_Dr_dr_c19",
+    "outputKey": "so6_so6_Dr6_dr5",
+  },
+  {
+    "damage": "453/434",
+    "inputKey": "So_so_Dr_Dr_c19",
+    "outputKey": "so6_so6_Dr6_Dr5",
+  },
+  {
+    "damage": "458/434",
+    "inputKey": "So_So_dr_dr_c19",
+    "outputKey": "so6_no_dr6_dr6",
+  },
+  {
+    "damage": "440/434",
+    "inputKey": "So_So_Dr_dr_c19",
+    "outputKey": "so6_so6_Dr6_dr5",
+  },
+  {
+    "damage": "453/434",
+    "inputKey": "So_So_Dr_Dr_c19",
+    "outputKey": "so6_so6_Dr6_Dr5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "so_so_dr_dr_c18",
+    "outputKey": "so6_so6_dr6_dr5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "so_so_Dr_dr_c18",
+    "outputKey": "so6_so6_dr6_dr5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "so_so_Dr_Dr_c18",
+    "outputKey": "so6_so6_dr6_dr5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "So_so_dr_dr_c18",
+    "outputKey": "so6_so6_dr6_dr5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "So_so_Dr_dr_c18",
+    "outputKey": "so6_so6_dr6_dr5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "So_so_Dr_Dr_c18",
+    "outputKey": "so6_so6_dr6_dr5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "So_So_dr_dr_c18",
+    "outputKey": "so6_so6_dr6_dr5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "So_So_Dr_dr_c18",
+    "outputKey": "so6_so6_dr6_dr5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "So_So_Dr_Dr_c18",
+    "outputKey": "so6_so6_dr6_dr5",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "so_so_dr_dr_c17",
+    "outputKey": "so6_so6_dr6_dr3",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "so_so_Dr_dr_c17",
+    "outputKey": "so6_so6_dr6_dr3",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "so_so_Dr_Dr_c17",
+    "outputKey": "so6_so6_dr6_dr3",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "So_so_dr_dr_c17",
+    "outputKey": "so6_so6_dr6_dr3",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "So_so_Dr_dr_c17",
+    "outputKey": "so6_so6_dr6_dr3",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "So_so_Dr_Dr_c17",
+    "outputKey": "so6_so6_dr6_dr3",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "So_So_dr_dr_c17",
+    "outputKey": "so6_so6_dr6_dr3",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "So_So_Dr_dr_c17",
+    "outputKey": "so6_so6_dr6_dr3",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "So_So_Dr_Dr_c17",
+    "outputKey": "so6_so6_dr6_dr3",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "so_so_dr_dr_c16",
+    "outputKey": "so6_so6_dr6_dr1",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "so_so_Dr_dr_c16",
+    "outputKey": "so6_so6_dr6_dr1",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "so_so_Dr_Dr_c16",
+    "outputKey": "so6_so6_dr6_dr1",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_so_dr_dr_c16",
+    "outputKey": "so6_so6_dr6_dr1",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_so_Dr_dr_c16",
+    "outputKey": "so6_so6_dr6_dr1",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_so_Dr_Dr_c16",
+    "outputKey": "so6_so6_dr6_dr1",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_So_dr_dr_c16",
+    "outputKey": "so6_so6_dr6_dr1",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_So_Dr_dr_c16",
+    "outputKey": "so6_so6_dr6_dr1",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_So_Dr_Dr_c16",
+    "outputKey": "so6_so6_dr6_dr1",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "so_so_dr_dr_c15",
+    "outputKey": "so6_so6_dr5_dr5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "so_so_Dr_dr_c15",
+    "outputKey": "so6_so6_dr5_dr5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "so_so_Dr_Dr_c15",
+    "outputKey": "so6_so6_dr5_dr5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_so_dr_dr_c15",
+    "outputKey": "so6_so6_dr5_dr5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_so_Dr_dr_c15",
+    "outputKey": "so6_so6_dr5_dr5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_so_Dr_Dr_c15",
+    "outputKey": "so6_so6_dr5_dr5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_So_dr_dr_c15",
+    "outputKey": "so6_so6_dr5_dr5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_So_Dr_dr_c15",
+    "outputKey": "so6_so6_dr5_dr5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_So_Dr_Dr_c15",
+    "outputKey": "so6_so6_dr5_dr5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "so_so_dr_dr_c14",
+    "outputKey": "so6_so5_dr5_dr5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "so_so_Dr_dr_c14",
+    "outputKey": "so6_so5_dr5_dr5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "so_so_Dr_Dr_c14",
+    "outputKey": "so6_so5_dr5_dr5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "So_so_dr_dr_c14",
+    "outputKey": "so6_so5_dr5_dr5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "So_so_Dr_dr_c14",
+    "outputKey": "so6_so5_dr5_dr5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "So_so_Dr_Dr_c14",
+    "outputKey": "so6_so5_dr5_dr5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "So_So_dr_dr_c14",
+    "outputKey": "so6_so5_dr5_dr5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "So_So_Dr_dr_c14",
+    "outputKey": "so6_so5_dr5_dr5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "So_So_Dr_Dr_c14",
+    "outputKey": "so6_so5_dr5_dr5",
+  },
+  {
+    "damage": "233/224",
+    "inputKey": "so_so_dr_dr_c13",
+    "outputKey": "so6_so1_dr5_dr5",
+  },
+  {
+    "damage": "233/224",
+    "inputKey": "so_so_Dr_dr_c13",
+    "outputKey": "so6_so1_dr5_dr5",
+  },
+  {
+    "damage": "233/224",
+    "inputKey": "so_so_Dr_Dr_c13",
+    "outputKey": "so6_so1_dr5_dr5",
+  },
+  {
+    "damage": "233/224",
+    "inputKey": "So_so_dr_dr_c13",
+    "outputKey": "so6_so1_dr5_dr5",
+  },
+  {
+    "damage": "233/224",
+    "inputKey": "So_so_Dr_dr_c13",
+    "outputKey": "so6_so1_dr5_dr5",
+  },
+  {
+    "damage": "233/224",
+    "inputKey": "So_so_Dr_Dr_c13",
+    "outputKey": "so6_so1_dr5_dr5",
+  },
+  {
+    "damage": "226/224",
+    "inputKey": "So_So_dr_dr_c13",
+    "outputKey": "So5_So5_dr5_dr5",
+  },
+  {
+    "damage": "226/224",
+    "inputKey": "So_So_Dr_dr_c13",
+    "outputKey": "So5_So5_dr5_dr5",
+  },
+  {
+    "damage": "226/224",
+    "inputKey": "So_So_Dr_Dr_c13",
+    "outputKey": "So5_So5_dr5_dr5",
+  },
+  {
+    "damage": "198/196",
+    "inputKey": "so_so_dr_dr_c12",
+    "outputKey": "so5_so1_dr5_dr5",
+  },
+  {
+    "damage": "198/196",
+    "inputKey": "so_so_Dr_dr_c12",
+    "outputKey": "so5_so5_dr5_Dr4",
+  },
+  {
+    "damage": "198/196",
+    "inputKey": "so_so_Dr_Dr_c12",
+    "outputKey": "so5_so5_dr5_Dr4",
+  },
+  {
+    "damage": "198/196",
+    "inputKey": "So_so_dr_dr_c12",
+    "outputKey": "so5_so1_dr5_dr5",
+  },
+  {
+    "damage": "198/196",
+    "inputKey": "So_so_Dr_dr_c12",
+    "outputKey": "so5_so5_dr5_Dr4",
+  },
+  {
+    "damage": "198/196",
+    "inputKey": "So_so_Dr_Dr_c12",
+    "outputKey": "so5_so5_dr5_Dr4",
+  },
+  {
+    "damage": "198/196",
+    "inputKey": "So_So_dr_dr_c12",
+    "outputKey": "so5_so1_dr5_dr5",
+  },
+  {
+    "damage": "198/196",
+    "inputKey": "So_So_Dr_dr_c12",
+    "outputKey": "so5_so5_dr5_Dr4",
+  },
+  {
+    "damage": "198/196",
+    "inputKey": "So_So_Dr_Dr_c12",
+    "outputKey": "so5_so5_dr5_Dr4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "so_so_dr_dr_c11",
+    "outputKey": "so5_so5_dr4_dr4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "so_so_Dr_dr_c11",
+    "outputKey": "so5_so5_dr4_dr4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "so_so_Dr_Dr_c11",
+    "outputKey": "so5_so5_dr4_dr4",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "So_so_dr_dr_c11",
+    "outputKey": "So5_so4_dr4_dr4",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "So_so_Dr_dr_c11",
+    "outputKey": "So5_so4_dr4_dr4",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "So_so_Dr_Dr_c11",
+    "outputKey": "So5_so4_dr4_dr4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "So_So_dr_dr_c11",
+    "outputKey": "So5_So4_dr4_dr4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "So_So_Dr_dr_c11",
+    "outputKey": "So5_So4_dr4_dr4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "So_So_Dr_Dr_c11",
+    "outputKey": "So5_So4_dr4_dr4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "so_so_dr_dr_c10",
+    "outputKey": "so4_so1_dr4_dr4",
+  },
+  {
+    "damage": "135/132",
+    "inputKey": "so_so_Dr_dr_c10",
+    "outputKey": "so4_so4_dr4_Dr3",
+  },
+  {
+    "damage": "135/132",
+    "inputKey": "so_so_Dr_Dr_c10",
+    "outputKey": "so4_so4_dr4_Dr3",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "So_so_dr_dr_c10",
+    "outputKey": "so4_so1_dr4_dr4",
+  },
+  {
+    "damage": "135/132",
+    "inputKey": "So_so_Dr_dr_c10",
+    "outputKey": "so4_so4_dr4_Dr3",
+  },
+  {
+    "damage": "135/132",
+    "inputKey": "So_so_Dr_Dr_c10",
+    "outputKey": "so4_so4_dr4_Dr3",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "So_So_dr_dr_c10",
+    "outputKey": "so4_so1_dr4_dr4",
+  },
+  {
+    "damage": "135/132",
+    "inputKey": "So_So_Dr_dr_c10",
+    "outputKey": "so4_so4_dr4_Dr3",
+  },
+  {
+    "damage": "135/132",
+    "inputKey": "So_So_Dr_Dr_c10",
+    "outputKey": "so4_so4_dr4_Dr3",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "so_so_dr_dr_c9",
+    "outputKey": "so4_so4_dr3_dr3",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "so_so_Dr_dr_c9",
+    "outputKey": "so4_so4_dr3_dr3",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "so_so_Dr_Dr_c9",
+    "outputKey": "so4_so4_dr3_dr3",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_so_dr_dr_c9",
+    "outputKey": "so4_so4_dr3_dr3",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_so_Dr_dr_c9",
+    "outputKey": "so4_so4_dr3_dr3",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_so_Dr_Dr_c9",
+    "outputKey": "so4_so4_dr3_dr3",
+  },
+  {
+    "damage": "110/110",
+    "inputKey": "So_So_dr_dr_c9",
+    "outputKey": "So4_So3_dr3_dr3",
+  },
+  {
+    "damage": "110/110",
+    "inputKey": "So_So_Dr_dr_c9",
+    "outputKey": "So4_So3_dr3_dr3",
+  },
+  {
+    "damage": "110/110",
+    "inputKey": "So_So_Dr_Dr_c9",
+    "outputKey": "So4_So3_dr3_dr3",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "so_so_dr_dr_c8",
+    "outputKey": "so3_so1_dr3_dr3",
+  },
+  {
+    "damage": "91/90",
+    "inputKey": "so_so_Dr_dr_c8",
+    "outputKey": "so3_so3_Dr3_dr2",
+  },
+  {
+    "damage": "95/90",
+    "inputKey": "so_so_Dr_Dr_c8",
+    "outputKey": "so3_so3_Dr3_Dr2",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "So_so_dr_dr_c8",
+    "outputKey": "so3_so1_dr3_dr3",
+  },
+  {
+    "damage": "91/90",
+    "inputKey": "So_so_Dr_dr_c8",
+    "outputKey": "so3_so3_Dr3_dr2",
+  },
+  {
+    "damage": "95/90",
+    "inputKey": "So_so_Dr_Dr_c8",
+    "outputKey": "so3_so3_Dr3_Dr2",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "So_So_dr_dr_c8",
+    "outputKey": "so3_so1_dr3_dr3",
+  },
+  {
+    "damage": "91/90",
+    "inputKey": "So_So_Dr_dr_c8",
+    "outputKey": "so3_so3_Dr3_dr2",
+  },
+  {
+    "damage": "95/90",
+    "inputKey": "So_So_Dr_Dr_c8",
+    "outputKey": "so3_so3_Dr3_Dr2",
+  },
+  {
+    "damage": "75/72",
+    "inputKey": "so_so_dr_dr_c7",
+    "outputKey": "so3_so3_dr3_dr1",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "so_so_Dr_dr_c7",
+    "outputKey": "so3_so3_Dr2_dr2",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "so_so_Dr_Dr_c7",
+    "outputKey": "so3_so3_Dr2_dr2",
+  },
+  {
+    "damage": "75/72",
+    "inputKey": "So_so_dr_dr_c7",
+    "outputKey": "so3_so3_dr3_dr1",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "So_so_Dr_dr_c7",
+    "outputKey": "so3_so3_Dr2_dr2",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "So_so_Dr_Dr_c7",
+    "outputKey": "so3_so3_Dr2_dr2",
+  },
+  {
+    "damage": "75/72",
+    "inputKey": "So_So_dr_dr_c7",
+    "outputKey": "so3_so3_dr3_dr1",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "So_So_Dr_dr_c7",
+    "outputKey": "so3_so3_Dr2_dr2",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "So_So_Dr_Dr_c7",
+    "outputKey": "so3_so3_Dr2_dr2",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "so_so_dr_dr_c6",
+    "outputKey": "so2_so1_dr2_dr2",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "so_so_Dr_dr_c6",
+    "outputKey": "so2_so1_dr2_dr2",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "so_so_Dr_Dr_c6",
+    "outputKey": "so2_so2_Dr2_Dr1",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_so_dr_dr_c6",
+    "outputKey": "so2_so1_dr2_dr2",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_so_Dr_dr_c6",
+    "outputKey": "so2_so1_dr2_dr2",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "So_so_Dr_Dr_c6",
+    "outputKey": "so2_so2_Dr2_Dr1",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_So_dr_dr_c6",
+    "outputKey": "so2_so1_dr2_dr2",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_So_Dr_dr_c6",
+    "outputKey": "so2_so1_dr2_dr2",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "So_So_Dr_Dr_c6",
+    "outputKey": "so2_so2_Dr2_Dr1",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "so_so_dr_dr_c5",
+    "outputKey": "so2_so2_dr2_dr1",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "so_so_Dr_dr_c5",
+    "outputKey": "so2_so2_Dr1_dr1",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "so_so_Dr_Dr_c5",
+    "outputKey": "so2_so2_Dr1_dr1",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "So_so_dr_dr_c5",
+    "outputKey": "so2_so2_dr2_dr1",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "So_so_Dr_dr_c5",
+    "outputKey": "so2_so2_Dr1_dr1",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "So_so_Dr_Dr_c5",
+    "outputKey": "so2_so2_Dr1_dr1",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "So_So_dr_dr_c5",
+    "outputKey": "so2_so2_dr2_dr1",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "So_So_Dr_dr_c5",
+    "outputKey": "so2_so2_Dr1_dr1",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "So_So_Dr_Dr_c5",
+    "outputKey": "so2_so2_Dr1_dr1",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "so_so_dr_dr_c4",
+    "outputKey": "so1_so1_dr1_dr1",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "so_so_Dr_dr_c4",
+    "outputKey": "so1_so1_dr1_dr1",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "so_so_Dr_Dr_c4",
+    "outputKey": "so1_so1_dr1_dr1",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "So_so_dr_dr_c4",
+    "outputKey": "so1_so1_dr1_dr1",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "So_so_Dr_dr_c4",
+    "outputKey": "so1_so1_dr1_dr1",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "So_so_Dr_Dr_c4",
+    "outputKey": "so1_so1_dr1_dr1",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "So_So_dr_dr_c4",
+    "outputKey": "so1_so1_dr1_dr1",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "So_So_Dr_dr_c4",
+    "outputKey": "so1_so1_dr1_dr1",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "So_So_Dr_Dr_c4",
+    "outputKey": "so1_so1_dr1_dr1",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "so_so_dr_dr_c3",
+    "outputKey": "so1_so1_dr1_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "so_so_Dr_dr_c3",
+    "outputKey": "so1_so1_dr1_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "so_so_Dr_Dr_c3",
+    "outputKey": "so1_so1_dr1_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_so_dr_dr_c3",
+    "outputKey": "so1_so1_dr1_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_so_Dr_dr_c3",
+    "outputKey": "so1_so1_dr1_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_so_Dr_Dr_c3",
+    "outputKey": "so1_so1_dr1_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_So_dr_dr_c3",
+    "outputKey": "so1_so1_dr1_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_So_Dr_dr_c3",
+    "outputKey": "so1_so1_dr1_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_So_Dr_Dr_c3",
+    "outputKey": "so1_so1_dr1_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "so_so_dr_dr_c2",
+    "outputKey": "so1_no_dr1_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "so_so_Dr_dr_c2",
+    "outputKey": "so1_no_dr1_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "so_so_Dr_Dr_c2",
+    "outputKey": "so1_no_dr1_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "So_so_dr_dr_c2",
+    "outputKey": "so1_no_dr1_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "So_so_Dr_dr_c2",
+    "outputKey": "so1_no_dr1_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "So_so_Dr_Dr_c2",
+    "outputKey": "so1_no_dr1_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "So_So_dr_dr_c2",
+    "outputKey": "so1_no_dr1_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "So_So_Dr_dr_c2",
+    "outputKey": "so1_no_dr1_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "So_So_Dr_Dr_c2",
+    "outputKey": "so1_no_dr1_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "so_so_dr_dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "so_so_Dr_dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "so_so_Dr_Dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_so_dr_dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_so_Dr_dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_so_Dr_Dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_So_dr_dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_So_Dr_dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_So_Dr_Dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "494/476",
+    "inputKey": "so_so_so_dr_c20",
+    "outputKey": "so7_so7_so7_dr6",
+  },
+  {
+    "damage": "494/476",
+    "inputKey": "so_so_so_Dr_c20",
+    "outputKey": "so7_so7_so7_dr6",
+  },
+  {
+    "damage": "494/476",
+    "inputKey": "So_so_so_dr_c20",
+    "outputKey": "so7_so7_so7_dr6",
+  },
+  {
+    "damage": "494/476",
+    "inputKey": "So_so_so_Dr_c20",
+    "outputKey": "so7_so7_so7_dr6",
+  },
+  {
+    "damage": "494/476",
+    "inputKey": "So_So_so_dr_c20",
+    "outputKey": "so7_so7_so7_dr6",
+  },
+  {
+    "damage": "494/476",
+    "inputKey": "So_So_so_Dr_c20",
+    "outputKey": "so7_so7_so7_dr6",
+  },
+  {
+    "damage": "494/476",
+    "inputKey": "So_So_So_dr_c20",
+    "outputKey": "so7_so7_so7_dr6",
+  },
+  {
+    "damage": "494/476",
+    "inputKey": "So_So_So_Dr_c20",
+    "outputKey": "so7_so7_so7_dr6",
+  },
+  {
+    "damage": "446/434",
+    "inputKey": "so_so_so_dr_c19",
+    "outputKey": "so7_so7_so6_dr6",
+  },
+  {
+    "damage": "446/434",
+    "inputKey": "so_so_so_Dr_c19",
+    "outputKey": "so7_so7_so6_dr6",
+  },
+  {
+    "damage": "446/434",
+    "inputKey": "So_so_so_dr_c19",
+    "outputKey": "so7_so7_so6_dr6",
+  },
+  {
+    "damage": "446/434",
+    "inputKey": "So_so_so_Dr_c19",
+    "outputKey": "so7_so7_so6_dr6",
+  },
+  {
+    "damage": "446/434",
+    "inputKey": "So_So_so_dr_c19",
+    "outputKey": "so7_so7_so6_dr6",
+  },
+  {
+    "damage": "446/434",
+    "inputKey": "So_So_so_Dr_c19",
+    "outputKey": "so7_so7_so6_dr6",
+  },
+  {
+    "damage": "446/434",
+    "inputKey": "So_So_So_dr_c19",
+    "outputKey": "so7_so7_so6_dr6",
+  },
+  {
+    "damage": "446/434",
+    "inputKey": "So_So_So_Dr_c19",
+    "outputKey": "so7_so7_so6_dr6",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "so_so_so_dr_c18",
+    "outputKey": "so7_so6_so6_dr6",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "so_so_so_Dr_c18",
+    "outputKey": "so7_so6_so6_dr6",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "So_so_so_dr_c18",
+    "outputKey": "so7_so6_so6_dr6",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "So_so_so_Dr_c18",
+    "outputKey": "so7_so6_so6_dr6",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "So_So_so_dr_c18",
+    "outputKey": "so7_so6_so6_dr6",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "So_So_so_Dr_c18",
+    "outputKey": "so7_so6_so6_dr6",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "So_So_So_dr_c18",
+    "outputKey": "so7_so6_so6_dr6",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "So_So_So_Dr_c18",
+    "outputKey": "so7_so6_so6_dr6",
+  },
+  {
+    "damage": "358/356",
+    "inputKey": "so_so_so_dr_c17",
+    "outputKey": "so7_so6_so4_dr6",
+  },
+  {
+    "damage": "358/356",
+    "inputKey": "so_so_so_Dr_c17",
+    "outputKey": "so7_so6_so4_dr6",
+  },
+  {
+    "damage": "356/356",
+    "inputKey": "So_so_so_dr_c17",
+    "outputKey": "So6_so6_so6_dr6",
+  },
+  {
+    "damage": "356/356",
+    "inputKey": "So_so_so_Dr_c17",
+    "outputKey": "So6_so6_so6_dr6",
+  },
+  {
+    "damage": "356/356",
+    "inputKey": "So_So_so_dr_c17",
+    "outputKey": "So6_so6_so6_dr6",
+  },
+  {
+    "damage": "356/356",
+    "inputKey": "So_So_so_Dr_c17",
+    "outputKey": "So6_so6_so6_dr6",
+  },
+  {
+    "damage": "356/356",
+    "inputKey": "So_So_So_dr_c17",
+    "outputKey": "So6_so6_so6_dr6",
+  },
+  {
+    "damage": "356/356",
+    "inputKey": "So_So_So_Dr_c17",
+    "outputKey": "So6_so6_so6_dr6",
+  },
+  {
+    "damage": "350/320",
+    "inputKey": "so_so_so_dr_c16",
+    "outputKey": "so6_so6_so6_dr6",
+  },
+  {
+    "damage": "350/320",
+    "inputKey": "so_so_so_Dr_c16",
+    "outputKey": "so6_so6_so6_dr6",
+  },
+  {
+    "damage": "350/320",
+    "inputKey": "So_so_so_dr_c16",
+    "outputKey": "so6_so6_so6_dr6",
+  },
+  {
+    "damage": "350/320",
+    "inputKey": "So_so_so_Dr_c16",
+    "outputKey": "so6_so6_so6_dr6",
+  },
+  {
+    "damage": "350/320",
+    "inputKey": "So_So_so_dr_c16",
+    "outputKey": "so6_so6_so6_dr6",
+  },
+  {
+    "damage": "350/320",
+    "inputKey": "So_So_so_Dr_c16",
+    "outputKey": "so6_so6_so6_dr6",
+  },
+  {
+    "damage": "350/320",
+    "inputKey": "So_So_So_dr_c16",
+    "outputKey": "so6_so6_so6_dr6",
+  },
+  {
+    "damage": "350/320",
+    "inputKey": "So_So_So_Dr_c16",
+    "outputKey": "so6_so6_so6_dr6",
+  },
+  {
+    "damage": "290/286",
+    "inputKey": "so_so_so_dr_c15",
+    "outputKey": "so6_so6_no_dr6",
+  },
+  {
+    "damage": "290/286",
+    "inputKey": "so_so_so_Dr_c15",
+    "outputKey": "so6_so6_no_dr6",
+  },
+  {
+    "damage": "290/286",
+    "inputKey": "So_so_so_dr_c15",
+    "outputKey": "so6_so6_no_dr6",
+  },
+  {
+    "damage": "290/286",
+    "inputKey": "So_so_so_Dr_c15",
+    "outputKey": "so6_so6_no_dr6",
+  },
+  {
+    "damage": "290/286",
+    "inputKey": "So_So_so_dr_c15",
+    "outputKey": "so6_so6_no_dr6",
+  },
+  {
+    "damage": "290/286",
+    "inputKey": "So_So_so_Dr_c15",
+    "outputKey": "so6_so6_no_dr6",
+  },
+  {
+    "damage": "290/286",
+    "inputKey": "So_So_So_dr_c15",
+    "outputKey": "so6_so6_no_dr6",
+  },
+  {
+    "damage": "290/286",
+    "inputKey": "So_So_So_Dr_c15",
+    "outputKey": "so6_so6_no_dr6",
+  },
+  {
+    "damage": "256/254",
+    "inputKey": "so_so_so_dr_c14",
+    "outputKey": "so6_so5_no_dr6",
+  },
+  {
+    "damage": "261/254",
+    "inputKey": "so_so_so_Dr_c14",
+    "outputKey": "so6_so6_so6_Dr5",
+  },
+  {
+    "damage": "256/254",
+    "inputKey": "So_so_so_dr_c14",
+    "outputKey": "so6_so5_no_dr6",
+  },
+  {
+    "damage": "261/254",
+    "inputKey": "So_so_so_Dr_c14",
+    "outputKey": "so6_so6_so6_Dr5",
+  },
+  {
+    "damage": "256/254",
+    "inputKey": "So_So_so_dr_c14",
+    "outputKey": "so6_so5_no_dr6",
+  },
+  {
+    "damage": "261/254",
+    "inputKey": "So_So_so_Dr_c14",
+    "outputKey": "so6_so6_so6_Dr5",
+  },
+  {
+    "damage": "256/254",
+    "inputKey": "So_So_So_dr_c14",
+    "outputKey": "so6_so5_no_dr6",
+  },
+  {
+    "damage": "261/254",
+    "inputKey": "So_So_So_Dr_c14",
+    "outputKey": "so6_so6_so6_Dr5",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "so_so_so_dr_c13",
+    "outputKey": "so6_so6_so6_dr4",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "so_so_so_Dr_c13",
+    "outputKey": "so6_so6_so6_dr4",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "So_so_so_dr_c13",
+    "outputKey": "so6_so6_so6_dr4",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "So_so_so_Dr_c13",
+    "outputKey": "so6_so6_so6_dr4",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "So_So_so_dr_c13",
+    "outputKey": "So6_so6_So5_dr5",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "So_So_so_Dr_c13",
+    "outputKey": "So6_so6_So5_dr5",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "So_So_So_dr_c13",
+    "outputKey": "So6_so6_So5_dr5",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "So_So_So_Dr_c13",
+    "outputKey": "So6_so6_So5_dr5",
+  },
+  {
+    "damage": "199/196",
+    "inputKey": "so_so_so_dr_c12",
+    "outputKey": "so6_so6_so2_dr5",
+  },
+  {
+    "damage": "199/196",
+    "inputKey": "so_so_so_Dr_c12",
+    "outputKey": "so6_so6_so2_dr5",
+  },
+  {
+    "damage": "199/196",
+    "inputKey": "So_so_so_dr_c12",
+    "outputKey": "so6_so6_so2_dr5",
+  },
+  {
+    "damage": "199/196",
+    "inputKey": "So_so_so_Dr_c12",
+    "outputKey": "so6_so6_so2_dr5",
+  },
+  {
+    "damage": "199/196",
+    "inputKey": "So_So_so_dr_c12",
+    "outputKey": "so6_so6_so2_dr5",
+  },
+  {
+    "damage": "199/196",
+    "inputKey": "So_So_so_Dr_c12",
+    "outputKey": "so6_so6_so2_dr5",
+  },
+  {
+    "damage": "199/196",
+    "inputKey": "So_So_So_dr_c12",
+    "outputKey": "so6_so6_so2_dr5",
+  },
+  {
+    "damage": "199/196",
+    "inputKey": "So_So_So_Dr_c12",
+    "outputKey": "so6_so6_so2_dr5",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "so_so_so_dr_c11",
+    "outputKey": "so6_so5_no_dr5",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "so_so_so_Dr_c11",
+    "outputKey": "so6_so5_no_dr5",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "So_so_so_dr_c11",
+    "outputKey": "so6_so5_no_dr5",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "So_so_so_Dr_c11",
+    "outputKey": "so6_so5_no_dr5",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "So_So_so_dr_c11",
+    "outputKey": "so6_so5_no_dr5",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "So_So_so_Dr_c11",
+    "outputKey": "so6_so5_no_dr5",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "So_So_So_dr_c11",
+    "outputKey": "So5_So5_So5_dr5",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "So_So_So_Dr_c11",
+    "outputKey": "So5_So5_So5_dr5",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "so_so_so_dr_c10",
+    "outputKey": "so5_so5_so3_dr5",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "so_so_so_Dr_c10",
+    "outputKey": "so5_so5_so3_dr5",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "So_so_so_dr_c10",
+    "outputKey": "so5_so5_so3_dr5",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "So_so_so_Dr_c10",
+    "outputKey": "so5_so5_so3_dr5",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "So_So_so_dr_c10",
+    "outputKey": "so5_so5_so3_dr5",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "So_So_so_Dr_c10",
+    "outputKey": "so5_so5_so3_dr5",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "So_So_So_dr_c10",
+    "outputKey": "so5_so5_so3_dr5",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "So_So_So_Dr_c10",
+    "outputKey": "so5_so5_so3_dr5",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "so_so_so_dr_c9",
+    "outputKey": "so5_so5_so4_dr4",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "so_so_so_Dr_c9",
+    "outputKey": "so5_so5_so4_dr4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_so_so_dr_c9",
+    "outputKey": "so5_So4_so4_dr4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_so_so_Dr_c9",
+    "outputKey": "so5_So4_so4_dr4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_So_so_dr_c9",
+    "outputKey": "so5_So4_so4_dr4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_So_so_Dr_c9",
+    "outputKey": "so5_So4_so4_dr4",
+  },
+  {
+    "damage": "110/110",
+    "inputKey": "So_So_So_dr_c9",
+    "outputKey": "So4_So4_So4_dr4",
+  },
+  {
+    "damage": "110/110",
+    "inputKey": "So_So_So_Dr_c9",
+    "outputKey": "So4_So4_So4_dr4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "so_so_so_dr_c8",
+    "outputKey": "so4_so4_so2_dr4",
+  },
+  {
+    "damage": "93/90",
+    "inputKey": "so_so_so_Dr_c8",
+    "outputKey": "so4_so4_so4_Dr3",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "So_so_so_dr_c8",
+    "outputKey": "so4_so4_so2_dr4",
+  },
+  {
+    "damage": "93/90",
+    "inputKey": "So_so_so_Dr_c8",
+    "outputKey": "so4_so4_so4_Dr3",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "So_So_so_dr_c8",
+    "outputKey": "so4_so4_so2_dr4",
+  },
+  {
+    "damage": "93/90",
+    "inputKey": "So_So_so_Dr_c8",
+    "outputKey": "so4_so4_so4_Dr3",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "So_So_So_dr_c8",
+    "outputKey": "so4_so4_so2_dr4",
+  },
+  {
+    "damage": "93/90",
+    "inputKey": "So_So_So_Dr_c8",
+    "outputKey": "so4_so4_so4_Dr3",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "so_so_so_dr_c7",
+    "outputKey": "so4_so3_so3_dr3",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "so_so_so_Dr_c7",
+    "outputKey": "so4_so3_so3_dr3",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_so_so_dr_c7",
+    "outputKey": "So3_so3_so3_dr3",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_so_so_Dr_c7",
+    "outputKey": "So3_so3_so3_dr3",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_So_so_dr_c7",
+    "outputKey": "So3_so3_so3_dr3",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_So_so_Dr_c7",
+    "outputKey": "So3_so3_so3_dr3",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_So_So_dr_c7",
+    "outputKey": "So3_so3_so3_dr3",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_So_So_Dr_c7",
+    "outputKey": "So3_so3_so3_dr3",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "so_so_so_dr_c6",
+    "outputKey": "so3_so3_so3_dr2",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "so_so_so_Dr_c6",
+    "outputKey": "so3_so3_so3_dr2",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "So_so_so_dr_c6",
+    "outputKey": "So3_so3_so2_dr2",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "So_so_so_Dr_c6",
+    "outputKey": "So3_so3_so2_dr2",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "So_So_so_dr_c6",
+    "outputKey": "So3_so3_So2_dr2",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "So_So_so_Dr_c6",
+    "outputKey": "So3_so3_So2_dr2",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "So_So_So_dr_c6",
+    "outputKey": "So3_so3_So2_dr2",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "So_So_So_Dr_c6",
+    "outputKey": "So3_so3_So2_dr2",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "so_so_so_dr_c5",
+    "outputKey": "so2_so2_so2_dr2",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "so_so_so_Dr_c5",
+    "outputKey": "so2_so2_so2_dr2",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "So_so_so_dr_c5",
+    "outputKey": "so2_so2_so2_dr2",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "So_so_so_Dr_c5",
+    "outputKey": "so2_so2_so2_dr2",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "So_So_so_dr_c5",
+    "outputKey": "so2_so2_so2_dr2",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "So_So_so_Dr_c5",
+    "outputKey": "so2_so2_so2_dr2",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "So_So_So_dr_c5",
+    "outputKey": "so2_so2_so2_dr2",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "So_So_So_Dr_c5",
+    "outputKey": "so2_so2_so2_dr2",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "so_so_so_dr_c4",
+    "outputKey": "so2_so2_so1_dr1",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "so_so_so_Dr_c4",
+    "outputKey": "so2_so2_so1_dr1",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "So_so_so_dr_c4",
+    "outputKey": "so2_So1_so1_dr1",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "So_so_so_Dr_c4",
+    "outputKey": "so2_So1_so1_dr1",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "So_So_so_dr_c4",
+    "outputKey": "so2_So1_so1_dr1",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "So_So_so_Dr_c4",
+    "outputKey": "so2_So1_so1_dr1",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "So_So_So_dr_c4",
+    "outputKey": "so2_So1_so1_dr1",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "So_So_So_Dr_c4",
+    "outputKey": "so2_So1_so1_dr1",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "so_so_so_dr_c3",
+    "outputKey": "so1_so1_no_dr1",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "so_so_so_Dr_c3",
+    "outputKey": "so1_so1_no_dr1",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_so_so_dr_c3",
+    "outputKey": "so1_so1_no_dr1",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_so_so_Dr_c3",
+    "outputKey": "so1_so1_no_dr1",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_So_so_dr_c3",
+    "outputKey": "so1_so1_no_dr1",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_So_so_Dr_c3",
+    "outputKey": "so1_so1_no_dr1",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_So_So_dr_c3",
+    "outputKey": "so1_so1_no_dr1",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_So_So_Dr_c3",
+    "outputKey": "so1_so1_no_dr1",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "so_so_so_dr_c2",
+    "outputKey": "so1_so1_so1_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "so_so_so_Dr_c2",
+    "outputKey": "so1_so1_so1_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "So_so_so_dr_c2",
+    "outputKey": "so1_so1_so1_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "So_so_so_Dr_c2",
+    "outputKey": "so1_so1_so1_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "So_So_so_dr_c2",
+    "outputKey": "So1_So1_no_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "So_So_so_Dr_c2",
+    "outputKey": "So1_So1_no_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "So_So_So_dr_c2",
+    "outputKey": "So1_So1_no_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "So_So_So_Dr_c2",
+    "outputKey": "So1_So1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "so_so_so_dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "so_so_so_Dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_so_so_dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_so_so_Dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_So_so_dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_So_so_Dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_So_So_dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_So_So_Dr_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+]
+`;
+
+exports[`findCombo > matches snapshot for all permutations relevant to combo grid 1`] = `
+[
+  {
+    "damage": "0/476",
+    "inputKey": "so_so_so_so_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "so_so_so_so_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_so_so_so_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_so_so_so_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_So_so_so_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_So_so_so_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_So_So_so_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_So_So_so_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "So_So_So_So_c20",
+    "outputKey": "So7_So7_So7_So7",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "So_So_So_So_min4_c20",
+    "outputKey": "So7_So7_So7_So7",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "so_so_so_so_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "so_so_so_so_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "443/434",
+    "inputKey": "So_so_so_so_c19",
+    "outputKey": "So7_so7_so7_so7",
+  },
+  {
+    "damage": "443/434",
+    "inputKey": "So_so_so_so_min4_c19",
+    "outputKey": "So7_so7_so7_so7",
+  },
+  {
+    "damage": "443/434",
+    "inputKey": "So_So_so_so_c19",
+    "outputKey": "So7_so7_so7_so7",
+  },
+  {
+    "damage": "443/434",
+    "inputKey": "So_So_so_so_min4_c19",
+    "outputKey": "So7_so7_so7_so7",
+  },
+  {
+    "damage": "443/434",
+    "inputKey": "So_So_So_so_c19",
+    "outputKey": "So7_so7_so7_so7",
+  },
+  {
+    "damage": "443/434",
+    "inputKey": "So_So_So_so_min4_c19",
+    "outputKey": "So7_so7_so7_so7",
+  },
+  {
+    "damage": "443/434",
+    "inputKey": "So_So_So_So_c19",
+    "outputKey": "So7_so7_so7_so7",
+  },
+  {
+    "damage": "443/434",
+    "inputKey": "So_So_So_So_min4_c19",
+    "outputKey": "So7_so7_so7_so7",
+  },
+  {
+    "damage": "432/394",
+    "inputKey": "so_so_so_so_c18",
+    "outputKey": "so7_so7_so7_so7",
+  },
+  {
+    "damage": "432/394",
+    "inputKey": "so_so_so_so_min4_c18",
+    "outputKey": "so7_so7_so7_so7",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "So_so_so_so_c18",
+    "outputKey": "So7_so7_so7_so6",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "So_so_so_so_min4_c18",
+    "outputKey": "So7_so7_so7_so6",
+  },
+  {
+    "damage": "401/394",
+    "inputKey": "So_So_so_so_c18",
+    "outputKey": "So7_so7_so7_So6",
+  },
+  {
+    "damage": "401/394",
+    "inputKey": "So_So_so_so_min4_c18",
+    "outputKey": "So7_so7_so7_So6",
+  },
+  {
+    "damage": "401/394",
+    "inputKey": "So_So_So_so_c18",
+    "outputKey": "So7_so7_so7_So6",
+  },
+  {
+    "damage": "401/394",
+    "inputKey": "So_So_So_so_min4_c18",
+    "outputKey": "So7_so7_so7_So6",
+  },
+  {
+    "damage": "401/394",
+    "inputKey": "So_So_So_So_c18",
+    "outputKey": "So7_so7_so7_So6",
+  },
+  {
+    "damage": "401/394",
+    "inputKey": "So_So_So_So_min4_c18",
+    "outputKey": "So7_so7_so7_So6",
+  },
+  {
+    "damage": "384/356",
+    "inputKey": "so_so_so_so_c17",
+    "outputKey": "so7_so7_so7_so6",
+  },
+  {
+    "damage": "384/356",
+    "inputKey": "so_so_so_so_min4_c17",
+    "outputKey": "so7_so7_so7_so6",
+  },
+  {
+    "damage": "384/356",
+    "inputKey": "So_so_so_so_c17",
+    "outputKey": "so7_so7_so7_so6",
+  },
+  {
+    "damage": "384/356",
+    "inputKey": "So_so_so_so_min4_c17",
+    "outputKey": "so7_so7_so7_so6",
+  },
+  {
+    "damage": "358/356",
+    "inputKey": "So_So_so_so_c17",
+    "outputKey": "So7_So7_so6_so6",
+  },
+  {
+    "damage": "358/356",
+    "inputKey": "So_So_so_so_min4_c17",
+    "outputKey": "So7_So7_so6_so6",
+  },
+  {
+    "damage": "359/356",
+    "inputKey": "So_So_So_so_c17",
+    "outputKey": "So7_so7_So6_So6",
+  },
+  {
+    "damage": "359/356",
+    "inputKey": "So_So_So_so_min4_c17",
+    "outputKey": "So7_so7_So6_So6",
+  },
+  {
+    "damage": "359/356",
+    "inputKey": "So_So_So_So_c17",
+    "outputKey": "So7_so7_So6_So6",
+  },
+  {
+    "damage": "359/356",
+    "inputKey": "So_So_So_So_min4_c17",
+    "outputKey": "So7_so7_So6_So6",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "so_so_so_so_c16",
+    "outputKey": "so7_so7_so6_so6",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "so_so_so_so_min4_c16",
+    "outputKey": "so7_so7_so6_so6",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_so_so_so_c16",
+    "outputKey": "so7_so7_so6_so6",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_so_so_so_min4_c16",
+    "outputKey": "so7_so7_so6_so6",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_So_so_so_c16",
+    "outputKey": "so7_so7_so6_so6",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_So_so_so_min4_c16",
+    "outputKey": "so7_so7_so6_so6",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_So_So_so_c16",
+    "outputKey": "so7_so7_so6_so6",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_So_So_so_min4_c16",
+    "outputKey": "so7_so7_so6_so6",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_So_So_So_c16",
+    "outputKey": "so7_so7_so6_so6",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "So_So_So_So_min4_c16",
+    "outputKey": "so7_so7_so6_so6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "so_so_so_so_c15",
+    "outputKey": "so7_so6_so6_so6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "so_so_so_so_min4_c15",
+    "outputKey": "so7_so6_so6_so6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_so_so_so_c15",
+    "outputKey": "so7_so6_so6_so6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_so_so_so_min4_c15",
+    "outputKey": "so7_so6_so6_so6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_So_so_so_c15",
+    "outputKey": "so7_so6_so6_so6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_So_so_so_min4_c15",
+    "outputKey": "so7_so6_so6_so6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_So_So_so_c15",
+    "outputKey": "so7_so6_so6_so6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_So_So_so_min4_c15",
+    "outputKey": "so7_so6_so6_so6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_So_So_So_c15",
+    "outputKey": "so7_so6_so6_so6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "So_So_So_So_min4_c15",
+    "outputKey": "so7_so6_so6_so6",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "so_so_so_so_c14",
+    "outputKey": "so7_so6_so6_so5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "so_so_so_so_min4_c14",
+    "outputKey": "so7_so6_so6_so5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "So_so_so_so_c14",
+    "outputKey": "so7_so6_so6_so5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "So_so_so_so_min4_c14",
+    "outputKey": "so7_so6_so6_so5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "So_So_so_so_c14",
+    "outputKey": "so7_so6_so6_so5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "So_So_so_so_min4_c14",
+    "outputKey": "so7_so6_so6_so5",
+  },
+  {
+    "damage": "258/254",
+    "inputKey": "So_So_So_so_c14",
+    "outputKey": "So6_So6_So6_so6",
+  },
+  {
+    "damage": "258/254",
+    "inputKey": "So_So_So_so_min4_c14",
+    "outputKey": "So6_So6_So6_so6",
+  },
+  {
+    "damage": "258/254",
+    "inputKey": "So_So_So_So_c14",
+    "outputKey": "So6_So6_So6_so6",
+  },
+  {
+    "damage": "258/254",
+    "inputKey": "So_So_So_So_min4_c14",
+    "outputKey": "So6_So6_So6_so6",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "so_so_so_so_c13",
+    "outputKey": "so6_so6_so6_so6",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "so_so_so_so_min4_c13",
+    "outputKey": "so6_so6_so6_so6",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "So_so_so_so_c13",
+    "outputKey": "so6_so6_so6_so6",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "So_so_so_so_min4_c13",
+    "outputKey": "so6_so6_so6_so6",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "So_So_so_so_c13",
+    "outputKey": "so6_so6_so6_so6",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "So_So_so_so_min4_c13",
+    "outputKey": "so6_so6_so6_so6",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "So_So_So_so_c13",
+    "outputKey": "So6_So6_So6_so5",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "So_So_So_so_min4_c13",
+    "outputKey": "So6_So6_So6_so5",
+  },
+  {
+    "damage": "227/224",
+    "inputKey": "So_So_So_So_c13",
+    "outputKey": "So6_So6_So6_So5",
+  },
+  {
+    "damage": "227/224",
+    "inputKey": "So_So_So_So_min4_c13",
+    "outputKey": "So6_So6_So6_So5",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "so_so_so_so_c12",
+    "outputKey": "so6_so6_so6_so4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "so_so_so_so_min4_c12",
+    "outputKey": "so6_so6_so6_so4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "So_so_so_so_c12",
+    "outputKey": "so6_so6_so6_so4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "So_so_so_so_min4_c12",
+    "outputKey": "so6_so6_so6_so4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "So_So_so_so_c12",
+    "outputKey": "so6_so6_so6_so4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "So_So_so_so_min4_c12",
+    "outputKey": "so6_so6_so6_so4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "So_So_So_so_c12",
+    "outputKey": "so6_so6_so6_so4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "So_So_So_so_min4_c12",
+    "outputKey": "so6_so6_so6_so4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "So_So_So_So_c12",
+    "outputKey": "so6_so6_so6_so4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "So_So_So_So_min4_c12",
+    "outputKey": "so6_so6_so6_so4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "so_so_so_so_c11",
+    "outputKey": "so6_so6_so5_so3",
+  },
+  {
+    "damage": "165/156",
+    "inputKey": "so_so_so_so_min4_c11",
+    "outputKey": "so6_so6_so5_so4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "So_so_so_so_c11",
+    "outputKey": "so6_so6_so5_so3",
+  },
+  {
+    "damage": "165/156",
+    "inputKey": "So_so_so_so_min4_c11",
+    "outputKey": "so6_so6_so5_so4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "So_So_so_so_c11",
+    "outputKey": "so6_so6_so5_so3",
+  },
+  {
+    "damage": "165/156",
+    "inputKey": "So_So_so_so_min4_c11",
+    "outputKey": "so6_so6_so5_so4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "So_So_So_so_c11",
+    "outputKey": "so6_so6_so5_so3",
+  },
+  {
+    "damage": "165/156",
+    "inputKey": "So_So_So_so_min4_c11",
+    "outputKey": "so6_so6_so5_so4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "So_So_So_So_c11",
+    "outputKey": "so6_so6_so5_so3",
+  },
+  {
+    "damage": "165/156",
+    "inputKey": "So_So_So_So_min4_c11",
+    "outputKey": "so6_so6_so5_so4",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "so_so_so_so_c10",
+    "outputKey": "so6_so5_so5_so5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "so_so_so_so_min4_c10",
+    "outputKey": "so6_so5_so5_so5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "So_so_so_so_c10",
+    "outputKey": "so6_so5_so5_so5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "So_so_so_so_min4_c10",
+    "outputKey": "so6_so5_so5_so5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "So_So_so_so_c10",
+    "outputKey": "so6_so5_so5_so5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "So_So_so_so_min4_c10",
+    "outputKey": "so6_so5_so5_so5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "So_So_So_so_c10",
+    "outputKey": "so6_so5_so5_so5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "So_So_So_so_min4_c10",
+    "outputKey": "so6_so5_so5_so5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "So_So_So_So_c10",
+    "outputKey": "so6_so5_so5_so5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "So_So_So_So_min4_c10",
+    "outputKey": "so6_so5_so5_so5",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "so_so_so_so_c9",
+    "outputKey": "so6_so5_so5_no",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "so_so_so_so_min4_c9",
+    "outputKey": "so6_so5_so5_no",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_so_so_so_c9",
+    "outputKey": "so6_so5_so5_no",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_so_so_so_min4_c9",
+    "outputKey": "so6_so5_so5_no",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_So_so_so_c9",
+    "outputKey": "so6_so5_so5_no",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_So_so_so_min4_c9",
+    "outputKey": "so6_so5_so5_no",
+  },
+  {
+    "damage": "112/110",
+    "inputKey": "So_So_So_so_c9",
+    "outputKey": "So5_So5_So5_so5",
+  },
+  {
+    "damage": "112/110",
+    "inputKey": "So_So_So_so_min4_c9",
+    "outputKey": "So5_So5_So5_so5",
+  },
+  {
+    "damage": "112/110",
+    "inputKey": "So_So_So_So_c9",
+    "outputKey": "So5_So5_So5_so5",
+  },
+  {
+    "damage": "112/110",
+    "inputKey": "So_So_So_So_min4_c9",
+    "outputKey": "So5_So5_So5_so5",
+  },
+  {
+    "damage": "95/90",
+    "inputKey": "so_so_so_so_c8",
+    "outputKey": "so5_so5_so5_so4",
+  },
+  {
+    "damage": "95/90",
+    "inputKey": "so_so_so_so_min4_c8",
+    "outputKey": "so5_so5_so5_so4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "So_so_so_so_c8",
+    "outputKey": "so5_so5_So4_so4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "So_so_so_so_min4_c8",
+    "outputKey": "so5_so5_So4_so4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "So_So_so_so_c8",
+    "outputKey": "so5_so5_So4_so4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "So_So_so_so_min4_c8",
+    "outputKey": "so5_so5_So4_so4",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "So_So_So_so_c8",
+    "outputKey": "so5_So4_So4_So4",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "So_So_So_so_min4_c8",
+    "outputKey": "so5_So4_So4_So4",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "So_So_So_So_c8",
+    "outputKey": "so5_So4_So4_So4",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "So_So_So_So_min4_c8",
+    "outputKey": "so5_So4_So4_So4",
+  },
+  {
+    "damage": "77/72",
+    "inputKey": "so_so_so_so_c7",
+    "outputKey": "so4_so4_so4_so4",
+  },
+  {
+    "damage": "77/72",
+    "inputKey": "so_so_so_so_min4_c7",
+    "outputKey": "so4_so4_so4_so4",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "So_so_so_so_c7",
+    "outputKey": "so4_so4_so4_So3",
+  },
+  {
+    "damage": "77/72",
+    "inputKey": "So_so_so_so_min4_c7",
+    "outputKey": "so4_so4_so4_so4",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "So_So_so_so_c7",
+    "outputKey": "so4_so4_so4_So3",
+  },
+  {
+    "damage": "77/72",
+    "inputKey": "So_So_so_so_min4_c7",
+    "outputKey": "so4_so4_so4_so4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_So_So_so_c7",
+    "outputKey": "So4_so4_So3_So3",
+  },
+  {
+    "damage": "77/72",
+    "inputKey": "So_So_So_so_min4_c7",
+    "outputKey": "so4_so4_so4_so4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_So_So_So_c7",
+    "outputKey": "So4_so4_So3_So3",
+  },
+  {
+    "damage": "77/72",
+    "inputKey": "So_So_So_So_min4_c7",
+    "outputKey": "so4_so4_so4_so4",
+  },
+  {
+    "damage": "59/56",
+    "inputKey": "so_so_so_so_c6",
+    "outputKey": "so4_so3_so3_so3",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "so_so_so_so_min4_c6",
+    "outputKey": "so4_so4_so4_no",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "So_so_so_so_c6",
+    "outputKey": "So3_so3_so3_so3",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_so_so_so_min4_c6",
+    "outputKey": "so4_so4_so4_no",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "So_So_so_so_c6",
+    "outputKey": "So3_so3_so3_so3",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_So_so_so_min4_c6",
+    "outputKey": "so4_so4_so4_no",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "So_So_So_so_c6",
+    "outputKey": "So3_So3_So3_so2",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_So_So_so_min4_c6",
+    "outputKey": "so4_so4_so4_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "So_So_So_So_c6",
+    "outputKey": "So3_So3_So3_So2",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_So_So_So_min4_c6",
+    "outputKey": "so4_so4_so4_no",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "so_so_so_so_c5",
+    "outputKey": "so3_so3_so2_so2",
+  },
+  {
+    "damage": "58/42",
+    "inputKey": "so_so_so_so_min4_c5",
+    "outputKey": "so4_so4_so4_no",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "So_so_so_so_c5",
+    "outputKey": "so3_so3_so2_so2",
+  },
+  {
+    "damage": "58/42",
+    "inputKey": "So_so_so_so_min4_c5",
+    "outputKey": "so4_so4_so4_no",
+  },
+  {
+    "damage": "42/42",
+    "inputKey": "So_So_so_so_c5",
+    "outputKey": "So3_So2_so2_so2",
+  },
+  {
+    "damage": "58/42",
+    "inputKey": "So_So_so_so_min4_c5",
+    "outputKey": "so4_so4_so4_no",
+  },
+  {
+    "damage": "42/42",
+    "inputKey": "So_So_So_so_c5",
+    "outputKey": "so3_So2_So2_So2",
+  },
+  {
+    "damage": "58/42",
+    "inputKey": "So_So_So_so_min4_c5",
+    "outputKey": "so4_so4_so4_no",
+  },
+  {
+    "damage": "42/42",
+    "inputKey": "So_So_So_So_c5",
+    "outputKey": "so3_So2_So2_So2",
+  },
+  {
+    "damage": "58/42",
+    "inputKey": "So_So_So_So_min4_c5",
+    "outputKey": "so4_so4_so4_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "so_so_so_so_c4",
+    "outputKey": "so2_so2_so2_so1",
+  },
+  {
+    "damage": "39/30",
+    "inputKey": "so_so_so_so_min4_c4",
+    "outputKey": "so4_so4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "So_so_so_so_c4",
+    "outputKey": "so2_so2_so2_so1",
+  },
+  {
+    "damage": "39/30",
+    "inputKey": "So_so_so_so_min4_c4",
+    "outputKey": "so4_so4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "So_So_so_so_c4",
+    "outputKey": "so2_so2_so2_so1",
+  },
+  {
+    "damage": "39/30",
+    "inputKey": "So_So_so_so_min4_c4",
+    "outputKey": "so4_so4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "So_So_So_so_c4",
+    "outputKey": "So2_so2_So1_So1",
+  },
+  {
+    "damage": "39/30",
+    "inputKey": "So_So_So_so_min4_c4",
+    "outputKey": "so4_so4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "So_So_So_So_c4",
+    "outputKey": "So2_so2_So1_So1",
+  },
+  {
+    "damage": "39/30",
+    "inputKey": "So_So_So_So_min4_c4",
+    "outputKey": "so4_so4_no_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "so_so_so_so_c3",
+    "outputKey": "so1_so1_so1_so1",
+  },
+  {
+    "damage": "39/20",
+    "inputKey": "so_so_so_so_min4_c3",
+    "outputKey": "so4_so4_no_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_so_so_so_c3",
+    "outputKey": "so1_so1_so1_so1",
+  },
+  {
+    "damage": "39/20",
+    "inputKey": "So_so_so_so_min4_c3",
+    "outputKey": "so4_so4_no_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_So_so_so_c3",
+    "outputKey": "so1_so1_so1_so1",
+  },
+  {
+    "damage": "39/20",
+    "inputKey": "So_So_so_so_min4_c3",
+    "outputKey": "so4_so4_no_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_So_So_so_c3",
+    "outputKey": "so1_so1_so1_so1",
+  },
+  {
+    "damage": "39/20",
+    "inputKey": "So_So_So_so_min4_c3",
+    "outputKey": "so4_so4_no_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_So_So_So_c3",
+    "outputKey": "so1_so1_so1_so1",
+  },
+  {
+    "damage": "39/20",
+    "inputKey": "So_So_So_So_min4_c3",
+    "outputKey": "so4_so4_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "so_so_so_so_c2",
+    "outputKey": "so1_so1_so1_no",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "so_so_so_so_min4_c2",
+    "outputKey": "so4_no_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "So_so_so_so_c2",
+    "outputKey": "so1_so1_so1_no",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "So_so_so_so_min4_c2",
+    "outputKey": "so4_no_no_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "So_So_so_so_c2",
+    "outputKey": "So1_So1_no_no",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "So_So_so_so_min4_c2",
+    "outputKey": "so4_no_no_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "So_So_So_so_c2",
+    "outputKey": "So1_So1_no_no",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "So_So_So_so_min4_c2",
+    "outputKey": "so4_no_no_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "So_So_So_So_c2",
+    "outputKey": "So1_So1_no_no",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "So_So_So_So_min4_c2",
+    "outputKey": "so4_no_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "so_so_so_so_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "so_so_so_so_min4_c1",
+    "outputKey": "so4_no_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_so_so_so_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "So_so_so_so_min4_c1",
+    "outputKey": "so4_no_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_So_so_so_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "So_So_so_so_min4_c1",
+    "outputKey": "so4_no_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_So_So_so_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "So_So_So_so_min4_c1",
+    "outputKey": "so4_no_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_So_So_So_c1",
+    "outputKey": "so1_so1_no_no",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "So_So_So_So_min4_c1",
+    "outputKey": "so4_no_no_no",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "so_so_so_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "so_so_so_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_so_so_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_so_so_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_So_so_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_So_so_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_So_So_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_So_So_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "so_so_so_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "so_so_so_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "So_so_so_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "So_so_so_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "So_So_so_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "So_So_so_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "So_So_So_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "So_So_So_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "so_so_so_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "so_so_so_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "So_so_so_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "So_so_so_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "So_So_so_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "So_So_so_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "So_So_So_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "So_So_So_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "so_so_so_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "so_so_so_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "So_so_so_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "So_so_so_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "So_So_so_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "So_So_so_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "So_So_So_c17",
+    "outputKey": "So7_So7_So7",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "So_So_So_min4_c17",
+    "outputKey": "So7_So7_So7",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "so_so_so_c16",
+    "outputKey": "so7_so7_so7",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "so_so_so_min4_c16",
+    "outputKey": "so7_so7_so7",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "So_so_so_c16",
+    "outputKey": "so7_so7_so7",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "So_so_so_min4_c16",
+    "outputKey": "so7_so7_so7",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "So_So_so_c16",
+    "outputKey": "so7_so7_so7",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "So_So_so_min4_c16",
+    "outputKey": "so7_so7_so7",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "So_So_So_c16",
+    "outputKey": "so7_so7_so7",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "So_So_So_min4_c16",
+    "outputKey": "so7_so7_so7",
+  },
+  {
+    "damage": "324/286",
+    "inputKey": "so_so_so_c15",
+    "outputKey": "so7_so7_so7",
+  },
+  {
+    "damage": "324/286",
+    "inputKey": "so_so_so_min4_c15",
+    "outputKey": "so7_so7_so7",
+  },
+  {
+    "damage": "287/286",
+    "inputKey": "So_so_so_c15",
+    "outputKey": "So7_so7_so6",
+  },
+  {
+    "damage": "287/286",
+    "inputKey": "So_so_so_min4_c15",
+    "outputKey": "So7_so7_so6",
+  },
+  {
+    "damage": "293/286",
+    "inputKey": "So_So_so_c15",
+    "outputKey": "So7_so7_So6",
+  },
+  {
+    "damage": "293/286",
+    "inputKey": "So_So_so_min4_c15",
+    "outputKey": "So7_so7_So6",
+  },
+  {
+    "damage": "293/286",
+    "inputKey": "So_So_So_c15",
+    "outputKey": "So7_so7_So6",
+  },
+  {
+    "damage": "293/286",
+    "inputKey": "So_So_So_min4_c15",
+    "outputKey": "So7_so7_So6",
+  },
+  {
+    "damage": "276/254",
+    "inputKey": "so_so_so_c14",
+    "outputKey": "so7_so7_so6",
+  },
+  {
+    "damage": "276/254",
+    "inputKey": "so_so_so_min4_c14",
+    "outputKey": "so7_so7_so6",
+  },
+  {
+    "damage": "276/254",
+    "inputKey": "So_so_so_c14",
+    "outputKey": "so7_so7_so6",
+  },
+  {
+    "damage": "276/254",
+    "inputKey": "So_so_so_min4_c14",
+    "outputKey": "so7_so7_so6",
+  },
+  {
+    "damage": "276/254",
+    "inputKey": "So_So_so_c14",
+    "outputKey": "so7_so7_so6",
+  },
+  {
+    "damage": "276/254",
+    "inputKey": "So_So_so_min4_c14",
+    "outputKey": "so7_so7_so6",
+  },
+  {
+    "damage": "276/254",
+    "inputKey": "So_So_So_c14",
+    "outputKey": "so7_so7_so6",
+  },
+  {
+    "damage": "276/254",
+    "inputKey": "So_So_So_min4_c14",
+    "outputKey": "so7_so7_so6",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "so_so_so_c13",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "so_so_so_min4_c13",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "So_so_so_c13",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "So_so_so_min4_c13",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "So_So_so_c13",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "So_So_so_min4_c13",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "So_So_So_c13",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "So_So_So_min4_c13",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "228/196",
+    "inputKey": "so_so_so_c12",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "228/196",
+    "inputKey": "so_so_so_min4_c12",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "228/196",
+    "inputKey": "So_so_so_c12",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "228/196",
+    "inputKey": "So_so_so_min4_c12",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "228/196",
+    "inputKey": "So_So_so_c12",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "228/196",
+    "inputKey": "So_So_so_min4_c12",
+    "outputKey": "so7_so6_so6",
+  },
+  {
+    "damage": "198/196",
+    "inputKey": "So_So_So_c12",
+    "outputKey": "So6_So6_So6",
+  },
+  {
+    "damage": "198/196",
+    "inputKey": "So_So_So_min4_c12",
+    "outputKey": "So6_So6_So6",
+  },
+  {
+    "damage": "180/156",
+    "inputKey": "so_so_so_c11",
+    "outputKey": "so6_so6_so6",
+  },
+  {
+    "damage": "180/156",
+    "inputKey": "so_so_so_min4_c11",
+    "outputKey": "so6_so6_so6",
+  },
+  {
+    "damage": "180/156",
+    "inputKey": "So_so_so_c11",
+    "outputKey": "so6_so6_so6",
+  },
+  {
+    "damage": "180/156",
+    "inputKey": "So_so_so_min4_c11",
+    "outputKey": "so6_so6_so6",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "So_So_so_c11",
+    "outputKey": "So6_So6_so5",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "So_So_so_min4_c11",
+    "outputKey": "So6_So6_so5",
+  },
+  {
+    "damage": "161/156",
+    "inputKey": "So_So_So_c11",
+    "outputKey": "So6_So6_So5",
+  },
+  {
+    "damage": "161/156",
+    "inputKey": "So_So_So_min4_c11",
+    "outputKey": "So6_So6_So5",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "so_so_so_c10",
+    "outputKey": "so6_so6_so3",
+  },
+  {
+    "damage": "140/132",
+    "inputKey": "so_so_so_min4_c10",
+    "outputKey": "so6_so6_so4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "So_so_so_c10",
+    "outputKey": "so6_so6_so3",
+  },
+  {
+    "damage": "140/132",
+    "inputKey": "So_so_so_min4_c10",
+    "outputKey": "so6_so6_so4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "So_So_so_c10",
+    "outputKey": "so6_so6_so3",
+  },
+  {
+    "damage": "140/132",
+    "inputKey": "So_So_so_min4_c10",
+    "outputKey": "so6_so6_so4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "So_So_So_c10",
+    "outputKey": "so6_so6_so3",
+  },
+  {
+    "damage": "140/132",
+    "inputKey": "So_So_So_min4_c10",
+    "outputKey": "so6_so6_so4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "so_so_so_c9",
+    "outputKey": "so6_so5_so5",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "so_so_so_min4_c9",
+    "outputKey": "so6_so5_so5",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_so_so_c9",
+    "outputKey": "so6_so5_so5",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_so_so_min4_c9",
+    "outputKey": "so6_so5_so5",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_So_so_c9",
+    "outputKey": "so6_so5_so5",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_So_so_min4_c9",
+    "outputKey": "so6_so5_so5",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_So_So_c9",
+    "outputKey": "so6_so5_so5",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "So_So_So_min4_c9",
+    "outputKey": "so6_so5_so5",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "so_so_so_c8",
+    "outputKey": "so6_so5_so1",
+  },
+  {
+    "damage": "105/90",
+    "inputKey": "so_so_so_min4_c8",
+    "outputKey": "so6_so5_so4",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "So_so_so_c8",
+    "outputKey": "so6_so5_so1",
+  },
+  {
+    "damage": "105/90",
+    "inputKey": "So_so_so_min4_c8",
+    "outputKey": "so6_so5_so4",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "So_So_so_c8",
+    "outputKey": "so6_so5_so1",
+  },
+  {
+    "damage": "105/90",
+    "inputKey": "So_So_so_min4_c8",
+    "outputKey": "so6_so5_so4",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "So_So_So_c8",
+    "outputKey": "so6_so5_so1",
+  },
+  {
+    "damage": "105/90",
+    "inputKey": "So_So_So_min4_c8",
+    "outputKey": "so6_so5_so4",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "so_so_so_c7",
+    "outputKey": "so5_so5_so5",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "so_so_so_min4_c7",
+    "outputKey": "so5_so5_so5",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_so_so_c7",
+    "outputKey": "so5_so5_So4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_so_so_min4_c7",
+    "outputKey": "so5_so5_So4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_So_so_c7",
+    "outputKey": "so5_so5_So4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_So_so_min4_c7",
+    "outputKey": "so5_so5_So4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_So_So_c7",
+    "outputKey": "So5_So4_So4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "So_So_So_min4_c7",
+    "outputKey": "So5_So4_So4",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "so_so_so_c6",
+    "outputKey": "so4_so4_so4",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "so_so_so_min4_c6",
+    "outputKey": "so4_so4_so4",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_so_so_c6",
+    "outputKey": "so4_so4_so4",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_so_so_min4_c6",
+    "outputKey": "so4_so4_so4",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "So_So_so_c6",
+    "outputKey": "So4_so4_So3",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_So_so_min4_c6",
+    "outputKey": "so4_so4_so4",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "So_So_So_c6",
+    "outputKey": "So4_so4_So3",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_So_So_min4_c6",
+    "outputKey": "so4_so4_so4",
+  },
+  {
+    "damage": "46/42",
+    "inputKey": "so_so_so_c5",
+    "outputKey": "so4_so3_so3",
+  },
+  {
+    "damage": "58/42",
+    "inputKey": "so_so_so_min4_c5",
+    "outputKey": "so4_so4_so4",
+  },
+  {
+    "damage": "42/42",
+    "inputKey": "So_so_so_c5",
+    "outputKey": "So3_so3_so3",
+  },
+  {
+    "damage": "58/42",
+    "inputKey": "So_so_so_min4_c5",
+    "outputKey": "so4_so4_so4",
+  },
+  {
+    "damage": "42/42",
+    "inputKey": "So_So_so_c5",
+    "outputKey": "So3_so3_so3",
+  },
+  {
+    "damage": "58/42",
+    "inputKey": "So_So_so_min4_c5",
+    "outputKey": "so4_so4_so4",
+  },
+  {
+    "damage": "42/42",
+    "inputKey": "So_So_So_c5",
+    "outputKey": "So3_so3_so3",
+  },
+  {
+    "damage": "58/42",
+    "inputKey": "So_So_So_min4_c5",
+    "outputKey": "so4_so4_so4",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "so_so_so_c4",
+    "outputKey": "so3_so2_so2",
+  },
+  {
+    "damage": "39/30",
+    "inputKey": "so_so_so_min4_c4",
+    "outputKey": "so4_so4_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "So_so_so_c4",
+    "outputKey": "so3_so2_so2",
+  },
+  {
+    "damage": "39/30",
+    "inputKey": "So_so_so_min4_c4",
+    "outputKey": "so4_so4_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "So_So_so_c4",
+    "outputKey": "so3_so2_so2",
+  },
+  {
+    "damage": "39/30",
+    "inputKey": "So_So_so_min4_c4",
+    "outputKey": "so4_so4_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "So_So_So_c4",
+    "outputKey": "so3_so2_so2",
+  },
+  {
+    "damage": "39/30",
+    "inputKey": "So_So_So_min4_c4",
+    "outputKey": "so4_so4_no",
+  },
+  {
+    "damage": "22/20",
+    "inputKey": "so_so_so_c3",
+    "outputKey": "so2_so2_so1",
+  },
+  {
+    "damage": "39/20",
+    "inputKey": "so_so_so_min4_c3",
+    "outputKey": "so4_so4_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_so_so_c3",
+    "outputKey": "so2_So1_so1",
+  },
+  {
+    "damage": "39/20",
+    "inputKey": "So_so_so_min4_c3",
+    "outputKey": "so4_so4_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_So_so_c3",
+    "outputKey": "so2_So1_so1",
+  },
+  {
+    "damage": "39/20",
+    "inputKey": "So_So_so_min4_c3",
+    "outputKey": "so4_so4_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_So_So_c3",
+    "outputKey": "so2_So1_so1",
+  },
+  {
+    "damage": "39/20",
+    "inputKey": "So_So_So_min4_c3",
+    "outputKey": "so4_so4_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "so_so_so_c2",
+    "outputKey": "so1_so1_so1",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "so_so_so_min4_c2",
+    "outputKey": "so4_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "So_so_so_c2",
+    "outputKey": "so1_so1_so1",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "So_so_so_min4_c2",
+    "outputKey": "so4_no_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "So_So_so_c2",
+    "outputKey": "So1_So1_no",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "So_So_so_min4_c2",
+    "outputKey": "so4_no_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "So_So_So_c2",
+    "outputKey": "So1_So1_no",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "So_So_So_min4_c2",
+    "outputKey": "so4_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "so_so_so_c1",
+    "outputKey": "so1_so1_no",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "so_so_so_min4_c1",
+    "outputKey": "so4_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_so_so_c1",
+    "outputKey": "so1_so1_no",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "So_so_so_min4_c1",
+    "outputKey": "so4_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_So_so_c1",
+    "outputKey": "so1_so1_no",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "So_So_so_min4_c1",
+    "outputKey": "so4_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_So_So_c1",
+    "outputKey": "so1_so1_no",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "So_So_So_min4_c1",
+    "outputKey": "so4_no_no",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "so_so_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "so_so_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_so_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_so_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_So_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_So_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "so_so_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "so_so_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "So_so_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "So_so_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "So_So_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "So_So_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "so_so_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "so_so_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "So_so_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "So_so_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "So_So_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "So_So_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "so_so_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "so_so_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "So_so_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "So_so_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "So_So_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "So_So_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "so_so_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "so_so_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "So_so_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "So_so_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "So_So_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "So_So_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "so_so_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "so_so_min4_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "So_so_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "So_so_min4_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "So_So_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "So_So_min4_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "so_so_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "so_so_min4_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "So_so_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "So_so_min4_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "So_So_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "So_So_min4_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "so_so_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "so_so_min4_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "227/224",
+    "inputKey": "So_so_c13",
+    "outputKey": "So7_so7",
+  },
+  {
+    "damage": "227/224",
+    "inputKey": "So_so_min4_c13",
+    "outputKey": "So7_so7",
+  },
+  {
+    "damage": "227/224",
+    "inputKey": "So_So_c13",
+    "outputKey": "So7_so7",
+  },
+  {
+    "damage": "227/224",
+    "inputKey": "So_So_min4_c13",
+    "outputKey": "So7_so7",
+  },
+  {
+    "damage": "216/196",
+    "inputKey": "so_so_c12",
+    "outputKey": "so7_so7",
+  },
+  {
+    "damage": "216/196",
+    "inputKey": "so_so_min4_c12",
+    "outputKey": "so7_so7",
+  },
+  {
+    "damage": "216/196",
+    "inputKey": "So_so_c12",
+    "outputKey": "so7_so7",
+  },
+  {
+    "damage": "216/196",
+    "inputKey": "So_so_min4_c12",
+    "outputKey": "so7_so7",
+  },
+  {
+    "damage": "216/196",
+    "inputKey": "So_So_c12",
+    "outputKey": "so7_so7",
+  },
+  {
+    "damage": "216/196",
+    "inputKey": "So_So_min4_c12",
+    "outputKey": "so7_so7",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "so_so_c11",
+    "outputKey": "so7_so6",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "so_so_min4_c11",
+    "outputKey": "so7_so6",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "So_so_c11",
+    "outputKey": "so7_so6",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "So_so_min4_c11",
+    "outputKey": "so7_so6",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "So_So_c11",
+    "outputKey": "so7_so6",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "So_So_min4_c11",
+    "outputKey": "so7_so6",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "so_so_c10",
+    "outputKey": "so7_so5",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "so_so_min4_c10",
+    "outputKey": "so7_so5",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "So_so_c10",
+    "outputKey": "so7_so5",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "So_so_min4_c10",
+    "outputKey": "so7_so5",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "So_So_c10",
+    "outputKey": "So6_So6",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "So_So_min4_c10",
+    "outputKey": "So6_So6",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "so_so_c9",
+    "outputKey": "so6_so6",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "so_so_min4_c9",
+    "outputKey": "so6_so6",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "So_so_c9",
+    "outputKey": "so6_so6",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "So_so_min4_c9",
+    "outputKey": "so6_so6",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "So_So_c9",
+    "outputKey": "so6_so6",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "So_So_min4_c9",
+    "outputKey": "so6_so6",
+  },
+  {
+    "damage": "120/90",
+    "inputKey": "so_so_c8",
+    "outputKey": "so6_so6",
+  },
+  {
+    "damage": "120/90",
+    "inputKey": "so_so_min4_c8",
+    "outputKey": "so6_so6",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "So_so_c8",
+    "outputKey": "So6_so5",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "So_so_min4_c8",
+    "outputKey": "So6_so5",
+  },
+  {
+    "damage": "95/90",
+    "inputKey": "So_So_c8",
+    "outputKey": "So6_So5",
+  },
+  {
+    "damage": "95/90",
+    "inputKey": "So_So_min4_c8",
+    "outputKey": "So6_So5",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "so_so_c7",
+    "outputKey": "so6_so3",
+  },
+  {
+    "damage": "80/72",
+    "inputKey": "so_so_min4_c7",
+    "outputKey": "so6_so4",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "So_so_c7",
+    "outputKey": "so6_so3",
+  },
+  {
+    "damage": "80/72",
+    "inputKey": "So_so_min4_c7",
+    "outputKey": "so6_so4",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "So_So_c7",
+    "outputKey": "so6_so3",
+  },
+  {
+    "damage": "80/72",
+    "inputKey": "So_So_min4_c7",
+    "outputKey": "so6_so4",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "so_so_c6",
+    "outputKey": "so6_so1",
+  },
+  {
+    "damage": "80/56",
+    "inputKey": "so_so_min4_c6",
+    "outputKey": "so6_so4",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "So_so_c6",
+    "outputKey": "so6_so1",
+  },
+  {
+    "damage": "80/56",
+    "inputKey": "So_so_min4_c6",
+    "outputKey": "so6_so4",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_So_c6",
+    "outputKey": "So5_So5",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "So_So_min4_c6",
+    "outputKey": "So5_So5",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "so_so_c5",
+    "outputKey": "so5_so4",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "so_so_min4_c5",
+    "outputKey": "so5_so4",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "So_so_c5",
+    "outputKey": "so5_so4",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "So_so_min4_c5",
+    "outputKey": "so5_so4",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "So_So_c5",
+    "outputKey": "So4_So4",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "So_So_min4_c5",
+    "outputKey": "So4_So4",
+  },
+  {
+    "damage": "33/30",
+    "inputKey": "so_so_c4",
+    "outputKey": "so4_so3",
+  },
+  {
+    "damage": "39/30",
+    "inputKey": "so_so_min4_c4",
+    "outputKey": "so4_so4",
+  },
+  {
+    "damage": "33/30",
+    "inputKey": "So_so_c4",
+    "outputKey": "so4_so3",
+  },
+  {
+    "damage": "39/30",
+    "inputKey": "So_so_min4_c4",
+    "outputKey": "so4_so4",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "So_So_c4",
+    "outputKey": "So3_So3",
+  },
+  {
+    "damage": "39/30",
+    "inputKey": "So_So_min4_c4",
+    "outputKey": "so4_so4",
+  },
+  {
+    "damage": "22/20",
+    "inputKey": "so_so_c3",
+    "outputKey": "so3_so2",
+  },
+  {
+    "damage": "39/20",
+    "inputKey": "so_so_min4_c3",
+    "outputKey": "so4_so4",
+  },
+  {
+    "damage": "22/20",
+    "inputKey": "So_so_c3",
+    "outputKey": "so3_so2",
+  },
+  {
+    "damage": "39/20",
+    "inputKey": "So_so_min4_c3",
+    "outputKey": "so4_so4",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "So_So_c3",
+    "outputKey": "So2_So2",
+  },
+  {
+    "damage": "39/20",
+    "inputKey": "So_So_min4_c3",
+    "outputKey": "so4_so4",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "so_so_c2",
+    "outputKey": "so2_so1",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "so_so_min4_c2",
+    "outputKey": "so4_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "So_so_c2",
+    "outputKey": "so2_so1",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "So_so_min4_c2",
+    "outputKey": "so4_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "So_So_c2",
+    "outputKey": "So1_So1",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "So_So_min4_c2",
+    "outputKey": "so4_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "so_so_c1",
+    "outputKey": "so1_so1",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "so_so_min4_c1",
+    "outputKey": "so4_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_so_c1",
+    "outputKey": "so1_so1",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "So_so_min4_c1",
+    "outputKey": "so4_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "So_So_c1",
+    "outputKey": "so1_so1",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "So_So_min4_c1",
+    "outputKey": "so4_no",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "so_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "so_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "So_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "so_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "so_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "So_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "So_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "so_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "so_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "So_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "So_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "so_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "so_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "So_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "So_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "so_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "so_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "So_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "So_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "so_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "so_min4_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "So_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "So_min4_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "so_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "so_min4_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "So_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "So_min4_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "so_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "so_min4_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "So_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "So_min4_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "so_c12",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "so_min4_c12",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "So_c12",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "So_min4_c12",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/156",
+    "inputKey": "so_c11",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/156",
+    "inputKey": "so_min4_c11",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/156",
+    "inputKey": "So_c11",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/156",
+    "inputKey": "So_min4_c11",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/132",
+    "inputKey": "so_c10",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/132",
+    "inputKey": "so_min4_c10",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/132",
+    "inputKey": "So_c10",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/132",
+    "inputKey": "So_min4_c10",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/110",
+    "inputKey": "so_c9",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/110",
+    "inputKey": "so_min4_c9",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/110",
+    "inputKey": "So_c9",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/110",
+    "inputKey": "So_min4_c9",
+    "outputKey": "",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "so_c8",
+    "outputKey": "so7",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "so_min4_c8",
+    "outputKey": "so7",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "So_c8",
+    "outputKey": "so7",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "So_min4_c8",
+    "outputKey": "so7",
+  },
+  {
+    "damage": "90/72",
+    "inputKey": "so_c7",
+    "outputKey": "so7",
+  },
+  {
+    "damage": "90/72",
+    "inputKey": "so_min4_c7",
+    "outputKey": "so7",
+  },
+  {
+    "damage": "90/72",
+    "inputKey": "So_c7",
+    "outputKey": "so7",
+  },
+  {
+    "damage": "90/72",
+    "inputKey": "So_min4_c7",
+    "outputKey": "so7",
+  },
+  {
+    "damage": "90/56",
+    "inputKey": "so_c6",
+    "outputKey": "so7",
+  },
+  {
+    "damage": "90/56",
+    "inputKey": "so_min4_c6",
+    "outputKey": "so7",
+  },
+  {
+    "damage": "90/56",
+    "inputKey": "So_c6",
+    "outputKey": "so7",
+  },
+  {
+    "damage": "90/56",
+    "inputKey": "So_min4_c6",
+    "outputKey": "so7",
+  },
+  {
+    "damage": "50/42",
+    "inputKey": "so_c5",
+    "outputKey": "so6",
+  },
+  {
+    "damage": "50/42",
+    "inputKey": "so_min4_c5",
+    "outputKey": "so6",
+  },
+  {
+    "damage": "50/42",
+    "inputKey": "So_c5",
+    "outputKey": "so6",
+  },
+  {
+    "damage": "50/42",
+    "inputKey": "So_min4_c5",
+    "outputKey": "so6",
+  },
+  {
+    "damage": "50/30",
+    "inputKey": "so_c4",
+    "outputKey": "so6",
+  },
+  {
+    "damage": "50/30",
+    "inputKey": "so_min4_c4",
+    "outputKey": "so6",
+  },
+  {
+    "damage": "50/30",
+    "inputKey": "So_c4",
+    "outputKey": "so6",
+  },
+  {
+    "damage": "50/30",
+    "inputKey": "So_min4_c4",
+    "outputKey": "so6",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "so_c3",
+    "outputKey": "so5",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "so_min4_c3",
+    "outputKey": "so5",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "So_c3",
+    "outputKey": "so5",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "So_min4_c3",
+    "outputKey": "so5",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "so_c2",
+    "outputKey": "so4",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "so_min4_c2",
+    "outputKey": "so4",
+  },
+  {
+    "damage": "13/12",
+    "inputKey": "So_c2",
+    "outputKey": "So3",
+  },
+  {
+    "damage": "16/12",
+    "inputKey": "So_min4_c2",
+    "outputKey": "so4",
+  },
+  {
+    "damage": "7/6",
+    "inputKey": "so_c1",
+    "outputKey": "so2",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "so_min4_c1",
+    "outputKey": "so4",
+  },
+  {
+    "damage": "7/6",
+    "inputKey": "So_c1",
+    "outputKey": "so2",
+  },
+  {
+    "damage": "16/6",
+    "inputKey": "So_min4_c1",
+    "outputKey": "so4",
+  },
+  {
+    "damage": "480/476",
+    "inputKey": "th_th_th_th_c20",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/476",
+    "inputKey": "th_th_th_th_min4_c20",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/476",
+    "inputKey": "Th_th_th_th_c20",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/476",
+    "inputKey": "Th_th_th_th_min4_c20",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/476",
+    "inputKey": "Th_Th_th_th_c20",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/476",
+    "inputKey": "Th_Th_th_th_min4_c20",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/476",
+    "inputKey": "Th_Th_Th_th_c20",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/476",
+    "inputKey": "Th_Th_Th_th_min4_c20",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/476",
+    "inputKey": "Th_Th_Th_Th_c20",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/476",
+    "inputKey": "Th_Th_Th_Th_min4_c20",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/434",
+    "inputKey": "th_th_th_th_c19",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/434",
+    "inputKey": "th_th_th_th_min4_c19",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/434",
+    "inputKey": "Th_th_th_th_c19",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/434",
+    "inputKey": "Th_th_th_th_min4_c19",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/434",
+    "inputKey": "Th_Th_th_th_c19",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "480/434",
+    "inputKey": "Th_Th_th_th_min4_c19",
+    "outputKey": "th6_th6_th6_th6",
+  },
+  {
+    "damage": "437/434",
+    "inputKey": "Th_Th_Th_th_c19",
+    "outputKey": "Th6_Th6_th6_Th5",
+  },
+  {
+    "damage": "437/434",
+    "inputKey": "Th_Th_Th_th_min4_c19",
+    "outputKey": "Th6_Th6_th6_Th5",
+  },
+  {
+    "damage": "437/434",
+    "inputKey": "Th_Th_Th_Th_c19",
+    "outputKey": "Th6_Th6_th6_Th5",
+  },
+  {
+    "damage": "437/434",
+    "inputKey": "Th_Th_Th_Th_min4_c19",
+    "outputKey": "Th6_Th6_th6_Th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "th_th_th_th_c18",
+    "outputKey": "th6_th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "th_th_th_th_min4_c18",
+    "outputKey": "th6_th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_th_th_th_c18",
+    "outputKey": "th6_th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_th_th_th_min4_c18",
+    "outputKey": "th6_th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_Th_th_th_c18",
+    "outputKey": "th6_th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_Th_th_th_min4_c18",
+    "outputKey": "th6_th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_Th_Th_th_c18",
+    "outputKey": "th6_th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_Th_Th_th_min4_c18",
+    "outputKey": "th6_th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_Th_Th_Th_c18",
+    "outputKey": "th6_th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_Th_Th_Th_min4_c18",
+    "outputKey": "th6_th6_th6_th5",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "th_th_th_th_c17",
+    "outputKey": "th6_th6_th6_no",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "th_th_th_th_min4_c17",
+    "outputKey": "th6_th6_th6_no",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Th_th_th_th_c17",
+    "outputKey": "th6_th6_th6_no",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Th_th_th_th_min4_c17",
+    "outputKey": "th6_th6_th6_no",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Th_Th_th_th_c17",
+    "outputKey": "Th6_Th6_th5_th5",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Th_Th_th_th_min4_c17",
+    "outputKey": "Th6_Th6_th5_th5",
+  },
+  {
+    "damage": "358/356",
+    "inputKey": "Th_Th_Th_th_c17",
+    "outputKey": "Th6_th6_Th5_Th5",
+  },
+  {
+    "damage": "358/356",
+    "inputKey": "Th_Th_Th_th_min4_c17",
+    "outputKey": "Th6_th6_Th5_Th5",
+  },
+  {
+    "damage": "358/356",
+    "inputKey": "Th_Th_Th_Th_c17",
+    "outputKey": "Th6_th6_Th5_Th5",
+  },
+  {
+    "damage": "358/356",
+    "inputKey": "Th_Th_Th_Th_min4_c17",
+    "outputKey": "Th6_th6_Th5_Th5",
+  },
+  {
+    "damage": "321/320",
+    "inputKey": "th_th_th_th_c16",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "321/320",
+    "inputKey": "th_th_th_th_min4_c16",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "321/320",
+    "inputKey": "Th_th_th_th_c16",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "321/320",
+    "inputKey": "Th_th_th_th_min4_c16",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "321/320",
+    "inputKey": "Th_Th_th_th_c16",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "321/320",
+    "inputKey": "Th_Th_th_th_min4_c16",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "321/320",
+    "inputKey": "Th_Th_Th_th_c16",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "321/320",
+    "inputKey": "Th_Th_Th_th_min4_c16",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "321/320",
+    "inputKey": "Th_Th_Th_Th_c16",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "321/320",
+    "inputKey": "Th_Th_Th_Th_min4_c16",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "th_th_th_th_c15",
+    "outputKey": "th6_th6_th5_no",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "th_th_th_th_min4_c15",
+    "outputKey": "th6_th6_th5_no",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Th_th_th_th_c15",
+    "outputKey": "th6_th6_th5_no",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Th_th_th_th_min4_c15",
+    "outputKey": "th6_th6_th5_no",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Th_Th_th_th_c15",
+    "outputKey": "th6_th6_th5_no",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Th_Th_th_th_min4_c15",
+    "outputKey": "th6_th6_th5_no",
+  },
+  {
+    "damage": "286/286",
+    "inputKey": "Th_Th_Th_th_c15",
+    "outputKey": "Th6_Th5_Th5_th5",
+  },
+  {
+    "damage": "286/286",
+    "inputKey": "Th_Th_Th_th_min4_c15",
+    "outputKey": "Th6_Th5_Th5_th5",
+  },
+  {
+    "damage": "291/286",
+    "inputKey": "Th_Th_Th_Th_c15",
+    "outputKey": "Th6_Th5_Th5_Th5",
+  },
+  {
+    "damage": "291/286",
+    "inputKey": "Th_Th_Th_Th_min4_c15",
+    "outputKey": "Th6_Th5_Th5_Th5",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "th_th_th_th_c14",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "th_th_th_th_min4_c14",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "Th_th_th_th_c14",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "Th_th_th_th_min4_c14",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "Th_Th_th_th_c14",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "Th_Th_th_th_min4_c14",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "Th_Th_Th_th_c14",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "Th_Th_Th_th_min4_c14",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "Th_Th_Th_Th_c14",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "Th_Th_Th_Th_min4_c14",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "th_th_th_th_c13",
+    "outputKey": "th6_th5_th5_th1",
+  },
+  {
+    "damage": "249/224",
+    "inputKey": "th_th_th_th_min4_c13",
+    "outputKey": "th6_th5_th5_th4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Th_th_th_th_c13",
+    "outputKey": "th6_th5_th5_th1",
+  },
+  {
+    "damage": "249/224",
+    "inputKey": "Th_th_th_th_min4_c13",
+    "outputKey": "th6_th5_th5_th4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Th_Th_th_th_c13",
+    "outputKey": "th6_th5_th5_th1",
+  },
+  {
+    "damage": "249/224",
+    "inputKey": "Th_Th_th_th_min4_c13",
+    "outputKey": "th6_th5_th5_th4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Th_Th_Th_th_c13",
+    "outputKey": "th6_th5_th5_th1",
+  },
+  {
+    "damage": "249/224",
+    "inputKey": "Th_Th_Th_th_min4_c13",
+    "outputKey": "th6_th5_th5_th4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Th_Th_Th_Th_c13",
+    "outputKey": "th6_th5_th5_th1",
+  },
+  {
+    "damage": "249/224",
+    "inputKey": "Th_Th_Th_Th_min4_c13",
+    "outputKey": "th6_th5_th5_th4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "th_th_th_th_c12",
+    "outputKey": "th6_th5_th4_no",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "th_th_th_th_min4_c12",
+    "outputKey": "th6_th5_th4_no",
+  },
+  {
+    "damage": "197/196",
+    "inputKey": "Th_th_th_th_c12",
+    "outputKey": "Th5_th5_th5_th5",
+  },
+  {
+    "damage": "197/196",
+    "inputKey": "Th_th_th_th_min4_c12",
+    "outputKey": "Th5_th5_th5_th5",
+  },
+  {
+    "damage": "197/196",
+    "inputKey": "Th_Th_th_th_c12",
+    "outputKey": "Th5_th5_th5_th5",
+  },
+  {
+    "damage": "197/196",
+    "inputKey": "Th_Th_th_th_min4_c12",
+    "outputKey": "Th5_th5_th5_th5",
+  },
+  {
+    "damage": "197/196",
+    "inputKey": "Th_Th_Th_th_c12",
+    "outputKey": "Th5_th5_th5_th5",
+  },
+  {
+    "damage": "197/196",
+    "inputKey": "Th_Th_Th_th_min4_c12",
+    "outputKey": "Th5_th5_th5_th5",
+  },
+  {
+    "damage": "197/196",
+    "inputKey": "Th_Th_Th_Th_c12",
+    "outputKey": "Th5_th5_th5_th5",
+  },
+  {
+    "damage": "197/196",
+    "inputKey": "Th_Th_Th_Th_min4_c12",
+    "outputKey": "Th5_th5_th5_th5",
+  },
+  {
+    "damage": "161/156",
+    "inputKey": "th_th_th_th_c11",
+    "outputKey": "th5_th5_th4_th4",
+  },
+  {
+    "damage": "161/156",
+    "inputKey": "th_th_th_th_min4_c11",
+    "outputKey": "th5_th5_th4_th4",
+  },
+  {
+    "damage": "161/156",
+    "inputKey": "Th_th_th_th_c11",
+    "outputKey": "th5_th5_th4_th4",
+  },
+  {
+    "damage": "161/156",
+    "inputKey": "Th_th_th_th_min4_c11",
+    "outputKey": "th5_th5_th4_th4",
+  },
+  {
+    "damage": "161/156",
+    "inputKey": "Th_Th_th_th_c11",
+    "outputKey": "th5_th5_th4_th4",
+  },
+  {
+    "damage": "161/156",
+    "inputKey": "Th_Th_th_th_min4_c11",
+    "outputKey": "th5_th5_th4_th4",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "Th_Th_Th_th_c11",
+    "outputKey": "th5_Th4_Th4_Th4",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "Th_Th_Th_th_min4_c11",
+    "outputKey": "th5_Th4_Th4_Th4",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "Th_Th_Th_Th_c11",
+    "outputKey": "th5_Th4_Th4_Th4",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "Th_Th_Th_Th_min4_c11",
+    "outputKey": "th5_Th4_Th4_Th4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "th_th_th_th_c10",
+    "outputKey": "th5_th4_th4_th3",
+  },
+  {
+    "damage": "146/132",
+    "inputKey": "th_th_th_th_min4_c10",
+    "outputKey": "th5_th4_th4_th4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "Th_th_th_th_c10",
+    "outputKey": "Th4_th4_th4_th4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "Th_th_th_th_min4_c10",
+    "outputKey": "Th4_th4_th4_th4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "Th_Th_th_th_c10",
+    "outputKey": "Th4_th4_th4_th4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "Th_Th_th_th_min4_c10",
+    "outputKey": "Th4_th4_th4_th4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "Th_Th_Th_th_c10",
+    "outputKey": "Th4_th4_th4_th4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "Th_Th_Th_th_min4_c10",
+    "outputKey": "Th4_th4_th4_th4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "Th_Th_Th_Th_c10",
+    "outputKey": "Th4_th4_th4_th4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "Th_Th_Th_Th_min4_c10",
+    "outputKey": "Th4_th4_th4_th4",
+  },
+  {
+    "damage": "110/110",
+    "inputKey": "th_th_th_th_c9",
+    "outputKey": "th4_th4_th4_th2",
+  },
+  {
+    "damage": "130/110",
+    "inputKey": "th_th_th_th_min4_c9",
+    "outputKey": "th4_th4_th4_th4",
+  },
+  {
+    "damage": "110/110",
+    "inputKey": "Th_th_th_th_c9",
+    "outputKey": "Th4_th4_th3_th3",
+  },
+  {
+    "damage": "130/110",
+    "inputKey": "Th_th_th_th_min4_c9",
+    "outputKey": "th4_th4_th4_th4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Th_Th_th_th_c9",
+    "outputKey": "th4_th4_Th3_Th3",
+  },
+  {
+    "damage": "130/110",
+    "inputKey": "Th_Th_th_th_min4_c9",
+    "outputKey": "th4_th4_th4_th4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Th_Th_Th_th_c9",
+    "outputKey": "th4_th4_Th3_Th3",
+  },
+  {
+    "damage": "130/110",
+    "inputKey": "Th_Th_Th_th_min4_c9",
+    "outputKey": "th4_th4_th4_th4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Th_Th_Th_Th_c9",
+    "outputKey": "th4_th4_Th3_Th3",
+  },
+  {
+    "damage": "130/110",
+    "inputKey": "Th_Th_Th_Th_min4_c9",
+    "outputKey": "th4_th4_th4_th4",
+  },
+  {
+    "damage": "94/90",
+    "inputKey": "th_th_th_th_c8",
+    "outputKey": "th4_th3_th3_th3",
+  },
+  {
+    "damage": "98/90",
+    "inputKey": "th_th_th_th_min4_c8",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "94/90",
+    "inputKey": "Th_th_th_th_c8",
+    "outputKey": "th4_th3_th3_th3",
+  },
+  {
+    "damage": "98/90",
+    "inputKey": "Th_th_th_th_min4_c8",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "94/90",
+    "inputKey": "Th_Th_th_th_c8",
+    "outputKey": "th4_th3_th3_th3",
+  },
+  {
+    "damage": "98/90",
+    "inputKey": "Th_Th_th_th_min4_c8",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "94/90",
+    "inputKey": "Th_Th_Th_th_c8",
+    "outputKey": "th4_th3_th3_th3",
+  },
+  {
+    "damage": "98/90",
+    "inputKey": "Th_Th_Th_th_min4_c8",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_Th_Th_Th_c8",
+    "outputKey": "Th3_Th3_Th3_Th3",
+  },
+  {
+    "damage": "98/90",
+    "inputKey": "Th_Th_Th_Th_min4_c8",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "th_th_th_th_c7",
+    "outputKey": "th3_th3_th3_th2",
+  },
+  {
+    "damage": "98/72",
+    "inputKey": "th_th_th_th_min4_c7",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "Th_th_th_th_c7",
+    "outputKey": "th3_th3_th3_th2",
+  },
+  {
+    "damage": "98/72",
+    "inputKey": "Th_th_th_th_min4_c7",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "Th_Th_th_th_c7",
+    "outputKey": "th3_th3_th3_th2",
+  },
+  {
+    "damage": "98/72",
+    "inputKey": "Th_Th_th_th_min4_c7",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "Th_Th_Th_th_c7",
+    "outputKey": "th3_th3_th3_th2",
+  },
+  {
+    "damage": "98/72",
+    "inputKey": "Th_Th_Th_th_min4_c7",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Th_Th_Th_Th_c7",
+    "outputKey": "Th3_Th3_Th2_Th2",
+  },
+  {
+    "damage": "98/72",
+    "inputKey": "Th_Th_Th_Th_min4_c7",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "th_th_th_th_c6",
+    "outputKey": "th3_th2_th2_th2",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "th_th_th_th_min4_c6",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Th_th_th_th_c6",
+    "outputKey": "th3_th2_th2_th2",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "Th_th_th_th_min4_c6",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Th_Th_th_th_c6",
+    "outputKey": "th3_th2_th2_th2",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "Th_Th_th_th_min4_c6",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Th_Th_Th_th_c6",
+    "outputKey": "th3_th2_th2_th2",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "Th_Th_Th_th_min4_c6",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Th_Th_Th_Th_c6",
+    "outputKey": "th3_th2_th2_th2",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "Th_Th_Th_Th_min4_c6",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "th_th_th_th_c5",
+    "outputKey": "th2_th2_th2_th1",
+  },
+  {
+    "damage": "65/42",
+    "inputKey": "th_th_th_th_min4_c5",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "Th_th_th_th_c5",
+    "outputKey": "th2_th2_th2_th1",
+  },
+  {
+    "damage": "65/42",
+    "inputKey": "Th_th_th_th_min4_c5",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "Th_Th_th_th_c5",
+    "outputKey": "th2_th2_th2_th1",
+  },
+  {
+    "damage": "65/42",
+    "inputKey": "Th_Th_th_th_min4_c5",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "42/42",
+    "inputKey": "Th_Th_Th_th_c5",
+    "outputKey": "Th2_th2_Th1_Th1",
+  },
+  {
+    "damage": "65/42",
+    "inputKey": "Th_Th_Th_th_min4_c5",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "42/42",
+    "inputKey": "Th_Th_Th_Th_c5",
+    "outputKey": "Th2_th2_Th1_Th1",
+  },
+  {
+    "damage": "65/42",
+    "inputKey": "Th_Th_Th_Th_min4_c5",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "th_th_th_th_c4",
+    "outputKey": "th2_th1_th1_th1",
+  },
+  {
+    "damage": "65/30",
+    "inputKey": "th_th_th_th_min4_c4",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Th_th_th_th_c4",
+    "outputKey": "Th1_th1_th1_th1",
+  },
+  {
+    "damage": "65/30",
+    "inputKey": "Th_th_th_th_min4_c4",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Th_Th_th_th_c4",
+    "outputKey": "Th1_th1_th1_th1",
+  },
+  {
+    "damage": "65/30",
+    "inputKey": "Th_Th_th_th_min4_c4",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Th_Th_Th_th_c4",
+    "outputKey": "Th1_th1_th1_th1",
+  },
+  {
+    "damage": "65/30",
+    "inputKey": "Th_Th_Th_th_min4_c4",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Th_Th_Th_Th_c4",
+    "outputKey": "Th1_th1_th1_th1",
+  },
+  {
+    "damage": "65/30",
+    "inputKey": "Th_Th_Th_Th_min4_c4",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "22/20",
+    "inputKey": "th_th_th_th_c3",
+    "outputKey": "th1_th1_th1_no",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "th_th_th_th_min4_c3",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "22/20",
+    "inputKey": "Th_th_th_th_c3",
+    "outputKey": "th1_th1_th1_no",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "Th_th_th_th_min4_c3",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "22/20",
+    "inputKey": "Th_Th_th_th_c3",
+    "outputKey": "th1_th1_th1_no",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "Th_Th_th_th_min4_c3",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "22/20",
+    "inputKey": "Th_Th_Th_th_c3",
+    "outputKey": "th1_th1_th1_no",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "Th_Th_Th_th_min4_c3",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "22/20",
+    "inputKey": "Th_Th_Th_Th_c3",
+    "outputKey": "th1_th1_th1_no",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "Th_Th_Th_Th_min4_c3",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "th_th_th_th_c2",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "th_th_th_th_min4_c2",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "Th_th_th_th_c2",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "Th_th_th_th_min4_c2",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "Th_Th_th_th_c2",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "Th_Th_th_th_min4_c2",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "Th_Th_Th_th_c2",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "Th_Th_Th_th_min4_c2",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "Th_Th_Th_Th_c2",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "Th_Th_Th_Th_min4_c2",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "th_th_th_th_c1",
+    "outputKey": "th1_no_no_no",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "th_th_th_th_min4_c1",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Th_th_th_th_c1",
+    "outputKey": "th1_no_no_no",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "Th_th_th_th_min4_c1",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Th_Th_th_th_c1",
+    "outputKey": "th1_no_no_no",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "Th_Th_th_th_min4_c1",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Th_Th_Th_th_c1",
+    "outputKey": "th1_no_no_no",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "Th_Th_Th_th_min4_c1",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Th_Th_Th_Th_c1",
+    "outputKey": "th1_no_no_no",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "Th_Th_Th_Th_min4_c1",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "th_th_th_th_c20_l",
+    "outputKey": "th6_th6_th5_th5",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "th_th_th_th_min4_c20_l",
+    "outputKey": "th6_th6_th5_th5",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "Th_th_th_th_c20_l",
+    "outputKey": "th6_th6_th5_th5",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "Th_th_th_th_min4_c20_l",
+    "outputKey": "th6_th6_th5_th5",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "Th_Th_th_th_c20_l",
+    "outputKey": "th6_th6_th5_th5",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "Th_Th_th_th_min4_c20_l",
+    "outputKey": "th6_th6_th5_th5",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "Th_Th_Th_th_c20_l",
+    "outputKey": "th6_th6_th5_th5",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "Th_Th_Th_th_min4_c20_l",
+    "outputKey": "th6_th6_th5_th5",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "Th_Th_Th_Th_c20_l",
+    "outputKey": "th6_th6_th5_th5",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "Th_Th_Th_Th_min4_c20_l",
+    "outputKey": "th6_th6_th5_th5",
+  },
+  {
+    "damage": "438/434",
+    "inputKey": "th_th_th_th_c19_l",
+    "outputKey": "th6_th6_th5_th3",
+  },
+  {
+    "damage": "455/434",
+    "inputKey": "th_th_th_th_min4_c19_l",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "438/434",
+    "inputKey": "Th_th_th_th_c19_l",
+    "outputKey": "th6_th6_th5_th3",
+  },
+  {
+    "damage": "455/434",
+    "inputKey": "Th_th_th_th_min4_c19_l",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "438/434",
+    "inputKey": "Th_Th_th_th_c19_l",
+    "outputKey": "th6_th6_th5_th3",
+  },
+  {
+    "damage": "455/434",
+    "inputKey": "Th_Th_th_th_min4_c19_l",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "438/434",
+    "inputKey": "Th_Th_Th_th_c19_l",
+    "outputKey": "th6_th6_th5_th3",
+  },
+  {
+    "damage": "455/434",
+    "inputKey": "Th_Th_Th_th_min4_c19_l",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "438/434",
+    "inputKey": "Th_Th_Th_Th_c19_l",
+    "outputKey": "th6_th6_th5_th3",
+  },
+  {
+    "damage": "455/434",
+    "inputKey": "Th_Th_Th_Th_min4_c19_l",
+    "outputKey": "th6_th6_th5_th4",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "th_th_th_th_c18_l",
+    "outputKey": "th6_th6_th5_no",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "th_th_th_th_min4_c18_l",
+    "outputKey": "th6_th6_th5_no",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_th_th_th_c18_l",
+    "outputKey": "th6_th6_th5_no",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_th_th_th_min4_c18_l",
+    "outputKey": "th6_th6_th5_no",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "Th_Th_th_th_c18_l",
+    "outputKey": "Th6_Th5_th5_th5",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "Th_Th_th_th_min4_c18_l",
+    "outputKey": "Th6_Th5_th5_th5",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "Th_Th_Th_th_c18_l",
+    "outputKey": "th6_Th5_Th5_Th5",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "Th_Th_Th_th_min4_c18_l",
+    "outputKey": "th6_Th5_Th5_Th5",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "Th_Th_Th_Th_c18_l",
+    "outputKey": "th6_Th5_Th5_Th5",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "Th_Th_Th_Th_min4_c18_l",
+    "outputKey": "th6_Th5_Th5_Th5",
+  },
+  {
+    "damage": "374/356",
+    "inputKey": "th_th_th_th_c17_l",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "374/356",
+    "inputKey": "th_th_th_th_min4_c17_l",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "374/356",
+    "inputKey": "Th_th_th_th_c17_l",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "374/356",
+    "inputKey": "Th_th_th_th_min4_c17_l",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "374/356",
+    "inputKey": "Th_Th_th_th_c17_l",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "374/356",
+    "inputKey": "Th_Th_th_th_min4_c17_l",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "374/356",
+    "inputKey": "Th_Th_Th_th_c17_l",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "374/356",
+    "inputKey": "Th_Th_Th_th_min4_c17_l",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "374/356",
+    "inputKey": "Th_Th_Th_Th_c17_l",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "374/356",
+    "inputKey": "Th_Th_Th_Th_min4_c17_l",
+    "outputKey": "th6_th5_th5_th5",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "th_th_th_th_c16_l",
+    "outputKey": "th6_th5_th5_th2",
+  },
+  {
+    "damage": "353/320",
+    "inputKey": "th_th_th_th_min4_c16_l",
+    "outputKey": "th6_th5_th5_th4",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Th_th_th_th_c16_l",
+    "outputKey": "th6_th5_th5_th2",
+  },
+  {
+    "damage": "353/320",
+    "inputKey": "Th_th_th_th_min4_c16_l",
+    "outputKey": "th6_th5_th5_th4",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Th_Th_th_th_c16_l",
+    "outputKey": "th6_th5_th5_th2",
+  },
+  {
+    "damage": "353/320",
+    "inputKey": "Th_Th_th_th_min4_c16_l",
+    "outputKey": "th6_th5_th5_th4",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Th_Th_Th_th_c16_l",
+    "outputKey": "th6_th5_th5_th2",
+  },
+  {
+    "damage": "353/320",
+    "inputKey": "Th_Th_Th_th_min4_c16_l",
+    "outputKey": "th6_th5_th5_th4",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Th_Th_Th_Th_c16_l",
+    "outputKey": "th6_th5_th5_th2",
+  },
+  {
+    "damage": "353/320",
+    "inputKey": "Th_Th_Th_Th_min4_c16_l",
+    "outputKey": "th6_th5_th5_th4",
+  },
+  {
+    "damage": "306/286",
+    "inputKey": "th_th_th_th_c15_l",
+    "outputKey": "th6_th5_th5_no",
+  },
+  {
+    "damage": "306/286",
+    "inputKey": "th_th_th_th_min4_c15_l",
+    "outputKey": "th6_th5_th5_no",
+  },
+  {
+    "damage": "306/286",
+    "inputKey": "Th_th_th_th_c15_l",
+    "outputKey": "th6_th5_th5_no",
+  },
+  {
+    "damage": "306/286",
+    "inputKey": "Th_th_th_th_min4_c15_l",
+    "outputKey": "th6_th5_th5_no",
+  },
+  {
+    "damage": "286/286",
+    "inputKey": "Th_Th_th_th_c15_l",
+    "outputKey": "Th5_Th5_th5_th5",
+  },
+  {
+    "damage": "286/286",
+    "inputKey": "Th_Th_th_th_min4_c15_l",
+    "outputKey": "Th5_Th5_th5_th5",
+  },
+  {
+    "damage": "286/286",
+    "inputKey": "Th_Th_Th_th_c15_l",
+    "outputKey": "Th5_Th5_th5_th5",
+  },
+  {
+    "damage": "286/286",
+    "inputKey": "Th_Th_Th_th_min4_c15_l",
+    "outputKey": "Th5_Th5_th5_th5",
+  },
+  {
+    "damage": "286/286",
+    "inputKey": "Th_Th_Th_Th_c15_l",
+    "outputKey": "Th5_Th5_th5_th5",
+  },
+  {
+    "damage": "286/286",
+    "inputKey": "Th_Th_Th_Th_min4_c15_l",
+    "outputKey": "Th5_Th5_th5_th5",
+  },
+  {
+    "damage": "272/254",
+    "inputKey": "th_th_th_th_c14_l",
+    "outputKey": "th5_th5_th5_th5",
+  },
+  {
+    "damage": "272/254",
+    "inputKey": "th_th_th_th_min4_c14_l",
+    "outputKey": "th5_th5_th5_th5",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Th_th_th_th_c14_l",
+    "outputKey": "th5_th5_th5_Th4",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Th_th_th_th_min4_c14_l",
+    "outputKey": "th5_th5_th5_Th4",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Th_Th_th_th_c14_l",
+    "outputKey": "th5_th5_th5_Th4",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Th_Th_th_th_min4_c14_l",
+    "outputKey": "th5_th5_th5_Th4",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Th_Th_Th_th_c14_l",
+    "outputKey": "th5_th5_th5_Th4",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Th_Th_Th_th_min4_c14_l",
+    "outputKey": "th5_th5_th5_Th4",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Th_Th_Th_Th_c14_l",
+    "outputKey": "th5_th5_th5_Th4",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Th_Th_Th_Th_min4_c14_l",
+    "outputKey": "th5_th5_th5_Th4",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "th_th_th_th_c13_l",
+    "outputKey": "th5_th5_th4_th4",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "th_th_th_th_min4_c13_l",
+    "outputKey": "th5_th5_th4_th4",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Th_th_th_th_c13_l",
+    "outputKey": "th5_th5_th4_th4",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Th_th_th_th_min4_c13_l",
+    "outputKey": "th5_th5_th4_th4",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Th_Th_th_th_c13_l",
+    "outputKey": "th5_th5_th4_th4",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Th_Th_th_th_min4_c13_l",
+    "outputKey": "th5_th5_th4_th4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Th_Th_Th_th_c13_l",
+    "outputKey": "Th5_Th4_Th4_th4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Th_Th_Th_th_min4_c13_l",
+    "outputKey": "Th5_Th4_Th4_th4",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Th_Th_Th_Th_c13_l",
+    "outputKey": "Th5_Th4_Th4_Th4",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Th_Th_Th_Th_min4_c13_l",
+    "outputKey": "Th5_Th4_Th4_Th4",
+  },
+  {
+    "damage": "207/196",
+    "inputKey": "th_th_th_th_c12_l",
+    "outputKey": "th5_th4_th4_th4",
+  },
+  {
+    "damage": "207/196",
+    "inputKey": "th_th_th_th_min4_c12_l",
+    "outputKey": "th5_th4_th4_th4",
+  },
+  {
+    "damage": "207/196",
+    "inputKey": "Th_th_th_th_c12_l",
+    "outputKey": "th5_th4_th4_th4",
+  },
+  {
+    "damage": "207/196",
+    "inputKey": "Th_th_th_th_min4_c12_l",
+    "outputKey": "th5_th4_th4_th4",
+  },
+  {
+    "damage": "207/196",
+    "inputKey": "Th_Th_th_th_c12_l",
+    "outputKey": "th5_th4_th4_th4",
+  },
+  {
+    "damage": "207/196",
+    "inputKey": "Th_Th_th_th_min4_c12_l",
+    "outputKey": "th5_th4_th4_th4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "Th_Th_Th_th_c12_l",
+    "outputKey": "Th4_Th4_Th4_th4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "Th_Th_Th_th_min4_c12_l",
+    "outputKey": "Th4_Th4_Th4_th4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "Th_Th_Th_Th_c12_l",
+    "outputKey": "Th4_Th4_Th4_th4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "Th_Th_Th_Th_min4_c12_l",
+    "outputKey": "Th4_Th4_Th4_th4",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "th_th_th_th_c11_l",
+    "outputKey": "th4_th4_th4_th2",
+  },
+  {
+    "damage": "184/156",
+    "inputKey": "th_th_th_th_min4_c11_l",
+    "outputKey": "th4_th4_th4_th4",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "Th_th_th_th_c11_l",
+    "outputKey": "Th4_th4_th3_th3",
+  },
+  {
+    "damage": "184/156",
+    "inputKey": "Th_th_th_th_min4_c11_l",
+    "outputKey": "th4_th4_th4_th4",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "Th_Th_th_th_c11_l",
+    "outputKey": "th4_th4_Th3_Th3",
+  },
+  {
+    "damage": "184/156",
+    "inputKey": "Th_Th_th_th_min4_c11_l",
+    "outputKey": "th4_th4_th4_th4",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "Th_Th_Th_th_c11_l",
+    "outputKey": "th4_th4_Th3_Th3",
+  },
+  {
+    "damage": "184/156",
+    "inputKey": "Th_Th_Th_th_min4_c11_l",
+    "outputKey": "th4_th4_th4_th4",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "Th_Th_Th_Th_c11_l",
+    "outputKey": "th4_th4_Th3_Th3",
+  },
+  {
+    "damage": "184/156",
+    "inputKey": "Th_Th_Th_Th_min4_c11_l",
+    "outputKey": "th4_th4_th4_th4",
+  },
+  {
+    "damage": "133/132",
+    "inputKey": "th_th_th_th_c10_l",
+    "outputKey": "th4_th3_th3_th3",
+  },
+  {
+    "damage": "139/132",
+    "inputKey": "th_th_th_th_min4_c10_l",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "133/132",
+    "inputKey": "Th_th_th_th_c10_l",
+    "outputKey": "th4_th3_th3_th3",
+  },
+  {
+    "damage": "139/132",
+    "inputKey": "Th_th_th_th_min4_c10_l",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "133/132",
+    "inputKey": "Th_Th_th_th_c10_l",
+    "outputKey": "th4_th3_th3_th3",
+  },
+  {
+    "damage": "139/132",
+    "inputKey": "Th_Th_th_th_min4_c10_l",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "133/132",
+    "inputKey": "Th_Th_Th_th_c10_l",
+    "outputKey": "th4_th3_th3_th3",
+  },
+  {
+    "damage": "139/132",
+    "inputKey": "Th_Th_Th_th_min4_c10_l",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "133/132",
+    "inputKey": "Th_Th_Th_Th_c10_l",
+    "outputKey": "th4_th3_th3_th3",
+  },
+  {
+    "damage": "139/132",
+    "inputKey": "Th_Th_Th_Th_min4_c10_l",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "116/110",
+    "inputKey": "th_th_th_th_c9_l",
+    "outputKey": "th3_th3_th3_th3",
+  },
+  {
+    "damage": "139/110",
+    "inputKey": "th_th_th_th_min4_c9_l",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "116/110",
+    "inputKey": "Th_th_th_th_c9_l",
+    "outputKey": "th3_th3_th3_th3",
+  },
+  {
+    "damage": "139/110",
+    "inputKey": "Th_th_th_th_min4_c9_l",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Th_Th_th_th_c9_l",
+    "outputKey": "Th3_Th3_th3_th2",
+  },
+  {
+    "damage": "139/110",
+    "inputKey": "Th_Th_th_th_min4_c9_l",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "113/110",
+    "inputKey": "Th_Th_Th_th_c9_l",
+    "outputKey": "Th3_Th3_th3_Th2",
+  },
+  {
+    "damage": "139/110",
+    "inputKey": "Th_Th_Th_th_min4_c9_l",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "113/110",
+    "inputKey": "Th_Th_Th_Th_c9_l",
+    "outputKey": "Th3_Th3_th3_Th2",
+  },
+  {
+    "damage": "139/110",
+    "inputKey": "Th_Th_Th_Th_min4_c9_l",
+    "outputKey": "th4_th4_th4_no",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "th_th_th_th_c8_l",
+    "outputKey": "th3_th3_th2_th2",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "th_th_th_th_min4_c8_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_th_th_th_c8_l",
+    "outputKey": "th3_th3_th2_th2",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_th_th_th_min4_c8_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_Th_th_th_c8_l",
+    "outputKey": "th3_th3_th2_th2",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_Th_th_th_min4_c8_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_Th_Th_th_c8_l",
+    "outputKey": "th3_th3_th2_th2",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_Th_Th_th_min4_c8_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_Th_Th_Th_c8_l",
+    "outputKey": "th3_th3_th2_th2",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_Th_Th_Th_min4_c8_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "th_th_th_th_c7_l",
+    "outputKey": "th3_th2_th2_th1",
+  },
+  {
+    "damage": "92/72",
+    "inputKey": "th_th_th_th_min4_c7_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "Th_th_th_th_c7_l",
+    "outputKey": "th3_th2_th2_th1",
+  },
+  {
+    "damage": "92/72",
+    "inputKey": "Th_th_th_th_min4_c7_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Th_Th_th_th_c7_l",
+    "outputKey": "Th2_Th2_th2_th2",
+  },
+  {
+    "damage": "92/72",
+    "inputKey": "Th_Th_th_th_min4_c7_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Th_Th_Th_th_c7_l",
+    "outputKey": "Th2_Th2_th2_th2",
+  },
+  {
+    "damage": "92/72",
+    "inputKey": "Th_Th_Th_th_min4_c7_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Th_Th_Th_Th_c7_l",
+    "outputKey": "Th2_Th2_th2_th2",
+  },
+  {
+    "damage": "92/72",
+    "inputKey": "Th_Th_Th_Th_min4_c7_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "62/56",
+    "inputKey": "th_th_th_th_c6_l",
+    "outputKey": "th2_th2_th2_th1",
+  },
+  {
+    "damage": "92/56",
+    "inputKey": "th_th_th_th_min4_c6_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Th_th_th_th_c6_l",
+    "outputKey": "th2_th2_Th1_th1",
+  },
+  {
+    "damage": "92/56",
+    "inputKey": "Th_th_th_th_min4_c6_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Th_Th_th_th_c6_l",
+    "outputKey": "th2_th2_Th1_th1",
+  },
+  {
+    "damage": "92/56",
+    "inputKey": "Th_Th_th_th_min4_c6_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Th_Th_Th_th_c6_l",
+    "outputKey": "th2_th2_Th1_th1",
+  },
+  {
+    "damage": "92/56",
+    "inputKey": "Th_Th_Th_th_min4_c6_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Th_Th_Th_Th_c6_l",
+    "outputKey": "th2_th2_Th1_th1",
+  },
+  {
+    "damage": "92/56",
+    "inputKey": "Th_Th_Th_Th_min4_c6_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "48/42",
+    "inputKey": "th_th_th_th_c5_l",
+    "outputKey": "th2_th1_th1_th1",
+  },
+  {
+    "damage": "92/42",
+    "inputKey": "th_th_th_th_min4_c5_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "43/42",
+    "inputKey": "Th_th_th_th_c5_l",
+    "outputKey": "Th1_th1_th1_th1",
+  },
+  {
+    "damage": "92/42",
+    "inputKey": "Th_th_th_th_min4_c5_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "43/42",
+    "inputKey": "Th_Th_th_th_c5_l",
+    "outputKey": "Th1_th1_th1_th1",
+  },
+  {
+    "damage": "92/42",
+    "inputKey": "Th_Th_th_th_min4_c5_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "43/42",
+    "inputKey": "Th_Th_Th_th_c5_l",
+    "outputKey": "Th1_th1_th1_th1",
+  },
+  {
+    "damage": "92/42",
+    "inputKey": "Th_Th_Th_th_min4_c5_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "43/42",
+    "inputKey": "Th_Th_Th_Th_c5_l",
+    "outputKey": "Th1_th1_th1_th1",
+  },
+  {
+    "damage": "92/42",
+    "inputKey": "Th_Th_Th_Th_min4_c5_l",
+    "outputKey": "th4_th4_no_no",
+  },
+  {
+    "damage": "31/30",
+    "inputKey": "th_th_th_th_c4_l",
+    "outputKey": "th1_th1_th1_no",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "th_th_th_th_min4_c4_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "31/30",
+    "inputKey": "Th_th_th_th_c4_l",
+    "outputKey": "th1_th1_th1_no",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "Th_th_th_th_min4_c4_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "31/30",
+    "inputKey": "Th_Th_th_th_c4_l",
+    "outputKey": "th1_th1_th1_no",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "Th_Th_th_th_min4_c4_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "31/30",
+    "inputKey": "Th_Th_Th_th_c4_l",
+    "outputKey": "th1_th1_th1_no",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "Th_Th_Th_th_min4_c4_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "31/30",
+    "inputKey": "Th_Th_Th_Th_c4_l",
+    "outputKey": "th1_th1_th1_no",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "Th_Th_Th_Th_min4_c4_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "th_th_th_th_c3_l",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "th_th_th_th_min4_c3_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Th_th_th_th_c3_l",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "Th_th_th_th_min4_c3_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Th_Th_th_th_c3_l",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "Th_Th_th_th_min4_c3_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Th_Th_Th_th_c3_l",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "Th_Th_Th_th_min4_c3_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Th_Th_Th_Th_c3_l",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "Th_Th_Th_Th_min4_c3_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "th_th_th_th_c2_l",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "th_th_th_th_min4_c2_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Th_th_th_th_c2_l",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "Th_th_th_th_min4_c2_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Th_Th_th_th_c2_l",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "Th_Th_th_th_min4_c2_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Th_Th_Th_th_c2_l",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "Th_Th_Th_th_min4_c2_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Th_Th_Th_Th_c2_l",
+    "outputKey": "th1_th1_no_no",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "Th_Th_Th_Th_min4_c2_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "th_th_th_th_c1_l",
+    "outputKey": "th1_no_no_no",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "th_th_th_th_min4_c1_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "Th_th_th_th_c1_l",
+    "outputKey": "th1_no_no_no",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "Th_th_th_th_min4_c1_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "Th_Th_th_th_c1_l",
+    "outputKey": "th1_no_no_no",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "Th_Th_th_th_min4_c1_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "Th_Th_Th_th_c1_l",
+    "outputKey": "th1_no_no_no",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "Th_Th_Th_th_min4_c1_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "Th_Th_Th_Th_c1_l",
+    "outputKey": "th1_no_no_no",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "Th_Th_Th_Th_min4_c1_l",
+    "outputKey": "th4_no_no_no",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "th_th_th_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "th_th_th_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_th_th_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_th_th_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_Th_th_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_Th_th_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "Th_Th_Th_c20",
+    "outputKey": "Th7_Th7_Th7",
+  },
+  {
+    "damage": "476/476",
+    "inputKey": "Th_Th_Th_min4_c20",
+    "outputKey": "Th7_Th7_Th7",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "th_th_th_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "th_th_th_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "447/434",
+    "inputKey": "Th_th_th_c19",
+    "outputKey": "Th7_th7_th7",
+  },
+  {
+    "damage": "447/434",
+    "inputKey": "Th_th_th_min4_c19",
+    "outputKey": "Th7_th7_th7",
+  },
+  {
+    "damage": "435/434",
+    "inputKey": "Th_Th_th_c19",
+    "outputKey": "Th7_th7_Th6",
+  },
+  {
+    "damage": "435/434",
+    "inputKey": "Th_Th_th_min4_c19",
+    "outputKey": "Th7_th7_Th6",
+  },
+  {
+    "damage": "435/434",
+    "inputKey": "Th_Th_Th_c19",
+    "outputKey": "Th7_th7_Th6",
+  },
+  {
+    "damage": "435/434",
+    "inputKey": "Th_Th_Th_min4_c19",
+    "outputKey": "Th7_th7_Th6",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "th_th_th_c18",
+    "outputKey": "th7_th7_th6",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "th_th_th_min4_c18",
+    "outputKey": "th7_th7_th6",
+  },
+  {
+    "damage": "396/394",
+    "inputKey": "Th_th_th_c18",
+    "outputKey": "th7_Th6_th6",
+  },
+  {
+    "damage": "396/394",
+    "inputKey": "Th_th_th_min4_c18",
+    "outputKey": "th7_Th6_th6",
+  },
+  {
+    "damage": "396/394",
+    "inputKey": "Th_Th_th_c18",
+    "outputKey": "th7_Th6_th6",
+  },
+  {
+    "damage": "396/394",
+    "inputKey": "Th_Th_th_min4_c18",
+    "outputKey": "th7_Th6_th6",
+  },
+  {
+    "damage": "396/394",
+    "inputKey": "Th_Th_Th_c18",
+    "outputKey": "Th6_Th6_Th6",
+  },
+  {
+    "damage": "396/394",
+    "inputKey": "Th_Th_Th_min4_c18",
+    "outputKey": "Th6_Th6_Th6",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "th_th_th_c17",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "th_th_th_min4_c17",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Th_th_th_c17",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Th_th_th_min4_c17",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Th_Th_th_c17",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Th_Th_th_min4_c17",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Th_Th_Th_c17",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Th_Th_Th_min4_c17",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/320",
+    "inputKey": "th_th_th_c16",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/320",
+    "inputKey": "th_th_th_min4_c16",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/320",
+    "inputKey": "Th_th_th_c16",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/320",
+    "inputKey": "Th_th_th_min4_c16",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/320",
+    "inputKey": "Th_Th_th_c16",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/320",
+    "inputKey": "Th_Th_th_min4_c16",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/320",
+    "inputKey": "Th_Th_Th_c16",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "360/320",
+    "inputKey": "Th_Th_Th_min4_c16",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "th_th_th_c15",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "th_th_th_min4_c15",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Th_th_th_c15",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Th_th_th_min4_c15",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Th_Th_th_c15",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Th_Th_th_min4_c15",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Th_Th_Th_c15",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Th_Th_Th_min4_c15",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "261/254",
+    "inputKey": "th_th_th_c14",
+    "outputKey": "th6_th6_th3",
+  },
+  {
+    "damage": "273/254",
+    "inputKey": "th_th_th_min4_c14",
+    "outputKey": "th6_th6_th4",
+  },
+  {
+    "damage": "261/254",
+    "inputKey": "Th_th_th_c14",
+    "outputKey": "th6_th6_th3",
+  },
+  {
+    "damage": "273/254",
+    "inputKey": "Th_th_th_min4_c14",
+    "outputKey": "th6_th6_th4",
+  },
+  {
+    "damage": "261/254",
+    "inputKey": "Th_Th_th_c14",
+    "outputKey": "th6_th6_th3",
+  },
+  {
+    "damage": "273/254",
+    "inputKey": "Th_Th_th_min4_c14",
+    "outputKey": "th6_th6_th4",
+  },
+  {
+    "damage": "261/254",
+    "inputKey": "Th_Th_Th_c14",
+    "outputKey": "th6_th6_th3",
+  },
+  {
+    "damage": "273/254",
+    "inputKey": "Th_Th_Th_min4_c14",
+    "outputKey": "th6_th6_th4",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "th_th_th_c13",
+    "outputKey": "th6_th6_no",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "th_th_th_min4_c13",
+    "outputKey": "th6_th6_no",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Th_th_th_c13",
+    "outputKey": "Th6_th5_th5",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Th_th_th_min4_c13",
+    "outputKey": "Th6_th5_th5",
+  },
+  {
+    "damage": "226/224",
+    "inputKey": "Th_Th_th_c13",
+    "outputKey": "th6_Th5_Th5",
+  },
+  {
+    "damage": "226/224",
+    "inputKey": "Th_Th_th_min4_c13",
+    "outputKey": "th6_Th5_Th5",
+  },
+  {
+    "damage": "226/224",
+    "inputKey": "Th_Th_Th_c13",
+    "outputKey": "th6_Th5_Th5",
+  },
+  {
+    "damage": "226/224",
+    "inputKey": "Th_Th_Th_min4_c13",
+    "outputKey": "th6_Th5_Th5",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "th_th_th_c12",
+    "outputKey": "th6_th5_th4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "th_th_th_min4_c12",
+    "outputKey": "th6_th5_th4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "Th_th_th_c12",
+    "outputKey": "th6_th5_th4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "Th_th_th_min4_c12",
+    "outputKey": "th6_th5_th4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "Th_Th_th_c12",
+    "outputKey": "th6_th5_th4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "Th_Th_th_min4_c12",
+    "outputKey": "th6_th5_th4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "Th_Th_Th_c12",
+    "outputKey": "th6_th5_th4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "Th_Th_Th_min4_c12",
+    "outputKey": "th6_th5_th4",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "th_th_th_c11",
+    "outputKey": "th6_th5_no",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "th_th_th_min4_c11",
+    "outputKey": "th6_th5_no",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "Th_th_th_c11",
+    "outputKey": "th6_th5_no",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "Th_th_th_min4_c11",
+    "outputKey": "th6_th5_no",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "Th_Th_th_c11",
+    "outputKey": "th6_th5_no",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "Th_Th_th_min4_c11",
+    "outputKey": "th6_th5_no",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "Th_Th_Th_c11",
+    "outputKey": "Th5_Th5_Th5",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "Th_Th_Th_min4_c11",
+    "outputKey": "Th5_Th5_Th5",
+  },
+  {
+    "damage": "144/132",
+    "inputKey": "th_th_th_c10",
+    "outputKey": "th5_th5_th5",
+  },
+  {
+    "damage": "144/132",
+    "inputKey": "th_th_th_min4_c10",
+    "outputKey": "th5_th5_th5",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Th_th_th_c10",
+    "outputKey": "th5_th5_Th4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Th_th_th_min4_c10",
+    "outputKey": "th5_th5_Th4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Th_Th_th_c10",
+    "outputKey": "th5_th5_Th4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Th_Th_th_min4_c10",
+    "outputKey": "th5_th5_Th4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Th_Th_Th_c10",
+    "outputKey": "th5_th5_Th4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Th_Th_Th_min4_c10",
+    "outputKey": "th5_th5_Th4",
+  },
+  {
+    "damage": "113/110",
+    "inputKey": "th_th_th_c9",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "113/110",
+    "inputKey": "th_th_th_min4_c9",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "113/110",
+    "inputKey": "Th_th_th_c9",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "113/110",
+    "inputKey": "Th_th_th_min4_c9",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "113/110",
+    "inputKey": "Th_Th_th_c9",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "113/110",
+    "inputKey": "Th_Th_th_min4_c9",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "113/110",
+    "inputKey": "Th_Th_Th_c9",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "113/110",
+    "inputKey": "Th_Th_Th_min4_c9",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "98/90",
+    "inputKey": "th_th_th_c8",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "98/90",
+    "inputKey": "th_th_th_min4_c8",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "98/90",
+    "inputKey": "Th_th_th_c8",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "98/90",
+    "inputKey": "Th_th_th_min4_c8",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_Th_th_c8",
+    "outputKey": "Th4_th4_Th3",
+  },
+  {
+    "damage": "98/90",
+    "inputKey": "Th_Th_th_min4_c8",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_Th_Th_c8",
+    "outputKey": "Th4_th4_Th3",
+  },
+  {
+    "damage": "98/90",
+    "inputKey": "Th_Th_Th_min4_c8",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "th_th_th_c7",
+    "outputKey": "th4_th3_th3",
+  },
+  {
+    "damage": "98/72",
+    "inputKey": "th_th_th_min4_c7",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "Th_th_th_c7",
+    "outputKey": "th4_th3_th3",
+  },
+  {
+    "damage": "98/72",
+    "inputKey": "Th_th_th_min4_c7",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "Th_Th_th_c7",
+    "outputKey": "th4_th3_th3",
+  },
+  {
+    "damage": "98/72",
+    "inputKey": "Th_Th_th_min4_c7",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "Th_Th_Th_c7",
+    "outputKey": "th4_th3_th3",
+  },
+  {
+    "damage": "98/72",
+    "inputKey": "Th_Th_Th_min4_c7",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "62/56",
+    "inputKey": "th_th_th_c6",
+    "outputKey": "th3_th3_th3",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "th_th_th_min4_c6",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "Th_th_th_c6",
+    "outputKey": "Th3_th3_th2",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "Th_th_th_min4_c6",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Th_Th_th_c6",
+    "outputKey": "Th3_th3_Th2",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "Th_Th_th_min4_c6",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Th_Th_Th_c6",
+    "outputKey": "Th3_th3_Th2",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "Th_Th_Th_min4_c6",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "th_th_th_c5",
+    "outputKey": "th3_th2_th2",
+  },
+  {
+    "damage": "65/42",
+    "inputKey": "th_th_th_min4_c5",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "Th_th_th_c5",
+    "outputKey": "th3_th2_th2",
+  },
+  {
+    "damage": "65/42",
+    "inputKey": "Th_th_th_min4_c5",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "Th_Th_th_c5",
+    "outputKey": "th3_th2_th2",
+  },
+  {
+    "damage": "65/42",
+    "inputKey": "Th_Th_th_min4_c5",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "Th_Th_Th_c5",
+    "outputKey": "th3_th2_th2",
+  },
+  {
+    "damage": "65/42",
+    "inputKey": "Th_Th_Th_min4_c5",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "th_th_th_c4",
+    "outputKey": "th2_th2_th1",
+  },
+  {
+    "damage": "65/30",
+    "inputKey": "th_th_th_min4_c4",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Th_th_th_c4",
+    "outputKey": "th2_th2_th1",
+  },
+  {
+    "damage": "65/30",
+    "inputKey": "Th_th_th_min4_c4",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Th_Th_th_c4",
+    "outputKey": "th2_th2_th1",
+  },
+  {
+    "damage": "65/30",
+    "inputKey": "Th_Th_th_min4_c4",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Th_Th_Th_c4",
+    "outputKey": "Th2_Th1_Th1",
+  },
+  {
+    "damage": "65/30",
+    "inputKey": "Th_Th_Th_min4_c4",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "22/20",
+    "inputKey": "th_th_th_c3",
+    "outputKey": "th1_th1_th1",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "th_th_th_min4_c3",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "22/20",
+    "inputKey": "Th_th_th_c3",
+    "outputKey": "th1_th1_th1",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "Th_th_th_min4_c3",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "22/20",
+    "inputKey": "Th_Th_th_c3",
+    "outputKey": "th1_th1_th1",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "Th_Th_th_min4_c3",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "22/20",
+    "inputKey": "Th_Th_Th_c3",
+    "outputKey": "th1_th1_th1",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "Th_Th_Th_min4_c3",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "th_th_th_c2",
+    "outputKey": "th1_th1_no",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "th_th_th_min4_c2",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "Th_th_th_c2",
+    "outputKey": "th1_th1_no",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "Th_th_th_min4_c2",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "Th_Th_th_c2",
+    "outputKey": "th1_th1_no",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "Th_Th_th_min4_c2",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "Th_Th_Th_c2",
+    "outputKey": "th1_th1_no",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "Th_Th_Th_min4_c2",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "th_th_th_c1",
+    "outputKey": "th1_no_no",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "th_th_th_min4_c1",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Th_th_th_c1",
+    "outputKey": "th1_no_no",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "Th_th_th_min4_c1",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Th_Th_th_c1",
+    "outputKey": "th1_no_no",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "Th_Th_th_min4_c1",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Th_Th_Th_c1",
+    "outputKey": "th1_no_no",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "Th_Th_Th_min4_c1",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "510/476",
+    "inputKey": "th_th_th_c20_l",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "510/476",
+    "inputKey": "th_th_th_min4_c20_l",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "510/476",
+    "inputKey": "Th_th_th_c20_l",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "510/476",
+    "inputKey": "Th_th_th_min4_c20_l",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "510/476",
+    "inputKey": "Th_Th_th_c20_l",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "510/476",
+    "inputKey": "Th_Th_th_min4_c20_l",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "510/476",
+    "inputKey": "Th_Th_Th_c20_l",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "510/476",
+    "inputKey": "Th_Th_Th_min4_c20_l",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "510/434",
+    "inputKey": "th_th_th_c19_l",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "510/434",
+    "inputKey": "th_th_th_min4_c19_l",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "510/434",
+    "inputKey": "Th_th_th_c19_l",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "510/434",
+    "inputKey": "Th_th_th_min4_c19_l",
+    "outputKey": "th6_th6_th6",
+  },
+  {
+    "damage": "442/434",
+    "inputKey": "Th_Th_th_c19_l",
+    "outputKey": "Th6_Th6_th5",
+  },
+  {
+    "damage": "442/434",
+    "inputKey": "Th_Th_th_min4_c19_l",
+    "outputKey": "Th6_Th6_th5",
+  },
+  {
+    "damage": "449/434",
+    "inputKey": "Th_Th_Th_c19_l",
+    "outputKey": "Th6_Th6_Th5",
+  },
+  {
+    "damage": "449/434",
+    "inputKey": "Th_Th_Th_min4_c19_l",
+    "outputKey": "Th6_Th6_Th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "th_th_th_c18_l",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "th_th_th_min4_c18_l",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_th_th_c18_l",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_th_th_min4_c18_l",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_Th_th_c18_l",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_Th_th_min4_c18_l",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_Th_Th_c18_l",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Th_Th_Th_min4_c18_l",
+    "outputKey": "th6_th6_th5",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "th_th_th_c17_l",
+    "outputKey": "th6_th6_th2",
+  },
+  {
+    "damage": "387/356",
+    "inputKey": "th_th_th_min4_c17_l",
+    "outputKey": "th6_th6_th4",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "Th_th_th_c17_l",
+    "outputKey": "th6_th6_th2",
+  },
+  {
+    "damage": "387/356",
+    "inputKey": "Th_th_th_min4_c17_l",
+    "outputKey": "th6_th6_th4",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "Th_Th_th_c17_l",
+    "outputKey": "th6_th6_th2",
+  },
+  {
+    "damage": "387/356",
+    "inputKey": "Th_Th_th_min4_c17_l",
+    "outputKey": "th6_th6_th4",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "Th_Th_Th_c17_l",
+    "outputKey": "th6_th6_th2",
+  },
+  {
+    "damage": "387/356",
+    "inputKey": "Th_Th_Th_min4_c17_l",
+    "outputKey": "th6_th6_th4",
+  },
+  {
+    "damage": "340/320",
+    "inputKey": "th_th_th_c16_l",
+    "outputKey": "th6_th6_no",
+  },
+  {
+    "damage": "340/320",
+    "inputKey": "th_th_th_min4_c16_l",
+    "outputKey": "th6_th6_no",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Th_th_th_c16_l",
+    "outputKey": "Th6_th5_th5",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Th_th_th_min4_c16_l",
+    "outputKey": "Th6_th5_th5",
+  },
+  {
+    "damage": "320/320",
+    "inputKey": "Th_Th_th_c16_l",
+    "outputKey": "th6_Th5_Th5",
+  },
+  {
+    "damage": "320/320",
+    "inputKey": "Th_Th_th_min4_c16_l",
+    "outputKey": "th6_Th5_Th5",
+  },
+  {
+    "damage": "320/320",
+    "inputKey": "Th_Th_Th_c16_l",
+    "outputKey": "th6_Th5_Th5",
+  },
+  {
+    "damage": "320/320",
+    "inputKey": "Th_Th_Th_min4_c16_l",
+    "outputKey": "th6_Th5_Th5",
+  },
+  {
+    "damage": "306/286",
+    "inputKey": "th_th_th_c15_l",
+    "outputKey": "th6_th5_th5",
+  },
+  {
+    "damage": "306/286",
+    "inputKey": "th_th_th_min4_c15_l",
+    "outputKey": "th6_th5_th5",
+  },
+  {
+    "damage": "306/286",
+    "inputKey": "Th_th_th_c15_l",
+    "outputKey": "th6_th5_th5",
+  },
+  {
+    "damage": "306/286",
+    "inputKey": "Th_th_th_min4_c15_l",
+    "outputKey": "th6_th5_th5",
+  },
+  {
+    "damage": "306/286",
+    "inputKey": "Th_Th_th_c15_l",
+    "outputKey": "th6_th5_th5",
+  },
+  {
+    "damage": "306/286",
+    "inputKey": "Th_Th_th_min4_c15_l",
+    "outputKey": "th6_th5_th5",
+  },
+  {
+    "damage": "306/286",
+    "inputKey": "Th_Th_Th_c15_l",
+    "outputKey": "th6_th5_th5",
+  },
+  {
+    "damage": "306/286",
+    "inputKey": "Th_Th_Th_min4_c15_l",
+    "outputKey": "th6_th5_th5",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "th_th_th_c14_l",
+    "outputKey": "th6_th5_th2",
+  },
+  {
+    "damage": "285/254",
+    "inputKey": "th_th_th_min4_c14_l",
+    "outputKey": "th6_th5_th4",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Th_th_th_c14_l",
+    "outputKey": "th6_th5_th2",
+  },
+  {
+    "damage": "285/254",
+    "inputKey": "Th_th_th_min4_c14_l",
+    "outputKey": "th6_th5_th4",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Th_Th_th_c14_l",
+    "outputKey": "th6_th5_th2",
+  },
+  {
+    "damage": "285/254",
+    "inputKey": "Th_Th_th_min4_c14_l",
+    "outputKey": "th6_th5_th4",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Th_Th_Th_c14_l",
+    "outputKey": "th6_th5_th2",
+  },
+  {
+    "damage": "285/254",
+    "inputKey": "Th_Th_Th_min4_c14_l",
+    "outputKey": "th6_th5_th4",
+  },
+  {
+    "damage": "238/224",
+    "inputKey": "th_th_th_c13_l",
+    "outputKey": "th6_th5_no",
+  },
+  {
+    "damage": "238/224",
+    "inputKey": "th_th_th_min4_c13_l",
+    "outputKey": "th6_th5_no",
+  },
+  {
+    "damage": "238/224",
+    "inputKey": "Th_th_th_c13_l",
+    "outputKey": "th6_th5_no",
+  },
+  {
+    "damage": "238/224",
+    "inputKey": "Th_th_th_min4_c13_l",
+    "outputKey": "th6_th5_no",
+  },
+  {
+    "damage": "238/224",
+    "inputKey": "Th_Th_th_c13_l",
+    "outputKey": "th6_th5_no",
+  },
+  {
+    "damage": "238/224",
+    "inputKey": "Th_Th_th_min4_c13_l",
+    "outputKey": "th6_th5_no",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "Th_Th_Th_c13_l",
+    "outputKey": "Th5_Th5_Th5",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "Th_Th_Th_min4_c13_l",
+    "outputKey": "Th5_Th5_Th5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "th_th_th_c12_l",
+    "outputKey": "th5_th5_th5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "th_th_th_min4_c12_l",
+    "outputKey": "th5_th5_th5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "Th_th_th_c12_l",
+    "outputKey": "th5_th5_th5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "Th_th_th_min4_c12_l",
+    "outputKey": "th5_th5_th5",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Th_Th_th_c12_l",
+    "outputKey": "Th5_Th5_th4",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Th_Th_th_min4_c12_l",
+    "outputKey": "Th5_Th5_th4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "Th_Th_Th_c12_l",
+    "outputKey": "Th5_Th5_Th4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "Th_Th_Th_min4_c12_l",
+    "outputKey": "Th5_Th5_Th4",
+  },
+  {
+    "damage": "160/156",
+    "inputKey": "th_th_th_c11_l",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "160/156",
+    "inputKey": "th_th_th_min4_c11_l",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "160/156",
+    "inputKey": "Th_th_th_c11_l",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "160/156",
+    "inputKey": "Th_th_th_min4_c11_l",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "160/156",
+    "inputKey": "Th_Th_th_c11_l",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "160/156",
+    "inputKey": "Th_Th_th_min4_c11_l",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "160/156",
+    "inputKey": "Th_Th_Th_c11_l",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "160/156",
+    "inputKey": "Th_Th_Th_min4_c11_l",
+    "outputKey": "th5_th4_th4",
+  },
+  {
+    "damage": "139/132",
+    "inputKey": "th_th_th_c10_l",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "139/132",
+    "inputKey": "th_th_th_min4_c10_l",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "139/132",
+    "inputKey": "Th_th_th_c10_l",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "139/132",
+    "inputKey": "Th_th_th_min4_c10_l",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Th_Th_th_c10_l",
+    "outputKey": "Th4_Th4_th3",
+  },
+  {
+    "damage": "139/132",
+    "inputKey": "Th_Th_th_min4_c10_l",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "135/132",
+    "inputKey": "Th_Th_Th_c10_l",
+    "outputKey": "Th4_Th4_Th3",
+  },
+  {
+    "damage": "139/132",
+    "inputKey": "Th_Th_Th_min4_c10_l",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "122/110",
+    "inputKey": "th_th_th_c9_l",
+    "outputKey": "th4_th4_th3",
+  },
+  {
+    "damage": "139/110",
+    "inputKey": "th_th_th_min4_c9_l",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "122/110",
+    "inputKey": "Th_th_th_c9_l",
+    "outputKey": "th4_th4_th3",
+  },
+  {
+    "damage": "139/110",
+    "inputKey": "Th_th_th_min4_c9_l",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Th_Th_th_c9_l",
+    "outputKey": "th4_Th3_Th3",
+  },
+  {
+    "damage": "139/110",
+    "inputKey": "Th_Th_th_min4_c9_l",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Th_Th_Th_c9_l",
+    "outputKey": "th4_Th3_Th3",
+  },
+  {
+    "damage": "139/110",
+    "inputKey": "Th_Th_Th_min4_c9_l",
+    "outputKey": "th4_th4_th4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "th_th_th_c8_l",
+    "outputKey": "th4_th3_th2",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "th_th_th_min4_c8_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "91/90",
+    "inputKey": "Th_th_th_c8_l",
+    "outputKey": "Th3_th3_th3",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_th_th_min4_c8_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "91/90",
+    "inputKey": "Th_Th_th_c8_l",
+    "outputKey": "Th3_th3_th3",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_Th_th_min4_c8_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "91/90",
+    "inputKey": "Th_Th_Th_c8_l",
+    "outputKey": "Th3_th3_th3",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_Th_Th_min4_c8_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "75/72",
+    "inputKey": "th_th_th_c7_l",
+    "outputKey": "th3_th3_th2",
+  },
+  {
+    "damage": "92/72",
+    "inputKey": "th_th_th_min4_c7_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "75/72",
+    "inputKey": "Th_th_th_c7_l",
+    "outputKey": "th3_th3_th2",
+  },
+  {
+    "damage": "92/72",
+    "inputKey": "Th_th_th_min4_c7_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "75/72",
+    "inputKey": "Th_Th_th_c7_l",
+    "outputKey": "th3_th3_th2",
+  },
+  {
+    "damage": "92/72",
+    "inputKey": "Th_Th_th_min4_c7_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "75/72",
+    "inputKey": "Th_Th_Th_c7_l",
+    "outputKey": "th3_th3_th2",
+  },
+  {
+    "damage": "92/72",
+    "inputKey": "Th_Th_Th_min4_c7_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "th_th_th_c6_l",
+    "outputKey": "th3_th2_th1",
+  },
+  {
+    "damage": "92/56",
+    "inputKey": "th_th_th_min4_c6_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Th_th_th_c6_l",
+    "outputKey": "th3_th2_th1",
+  },
+  {
+    "damage": "92/56",
+    "inputKey": "Th_th_th_min4_c6_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Th_Th_th_c6_l",
+    "outputKey": "th3_th2_th1",
+  },
+  {
+    "damage": "92/56",
+    "inputKey": "Th_Th_th_min4_c6_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Th_Th_Th_c6_l",
+    "outputKey": "Th2_Th2_Th2",
+  },
+  {
+    "damage": "92/56",
+    "inputKey": "Th_Th_Th_min4_c6_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "th_th_th_c5_l",
+    "outputKey": "th2_th2_th1",
+  },
+  {
+    "damage": "92/42",
+    "inputKey": "th_th_th_min4_c5_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "Th_th_th_c5_l",
+    "outputKey": "th2_th2_th1",
+  },
+  {
+    "damage": "92/42",
+    "inputKey": "Th_th_th_min4_c5_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "Th_Th_th_c5_l",
+    "outputKey": "th2_th2_th1",
+  },
+  {
+    "damage": "92/42",
+    "inputKey": "Th_Th_th_min4_c5_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "43/42",
+    "inputKey": "Th_Th_Th_c5_l",
+    "outputKey": "Th2_Th1_Th1",
+  },
+  {
+    "damage": "92/42",
+    "inputKey": "Th_Th_Th_min4_c5_l",
+    "outputKey": "th4_th4_no",
+  },
+  {
+    "damage": "31/30",
+    "inputKey": "th_th_th_c4_l",
+    "outputKey": "th1_th1_th1",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "th_th_th_min4_c4_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "31/30",
+    "inputKey": "Th_th_th_c4_l",
+    "outputKey": "th1_th1_th1",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "Th_th_th_min4_c4_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "31/30",
+    "inputKey": "Th_Th_th_c4_l",
+    "outputKey": "th1_th1_th1",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "Th_Th_th_min4_c4_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "31/30",
+    "inputKey": "Th_Th_Th_c4_l",
+    "outputKey": "th1_th1_th1",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "Th_Th_Th_min4_c4_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "th_th_th_c3_l",
+    "outputKey": "th1_th1_no",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "th_th_th_min4_c3_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Th_th_th_c3_l",
+    "outputKey": "th1_th1_no",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "Th_th_th_min4_c3_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Th_Th_th_c3_l",
+    "outputKey": "th1_th1_no",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "Th_Th_th_min4_c3_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Th_Th_Th_c3_l",
+    "outputKey": "th1_th1_no",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "Th_Th_Th_min4_c3_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "th_th_th_c2_l",
+    "outputKey": "th1_th1_no",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "th_th_th_min4_c2_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Th_th_th_c2_l",
+    "outputKey": "th1_th1_no",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "Th_th_th_min4_c2_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Th_Th_th_c2_l",
+    "outputKey": "th1_th1_no",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "Th_Th_th_min4_c2_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Th_Th_Th_c2_l",
+    "outputKey": "th1_th1_no",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "Th_Th_Th_min4_c2_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "th_th_th_c1_l",
+    "outputKey": "th1_no_no",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "th_th_th_min4_c1_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "Th_th_th_c1_l",
+    "outputKey": "th1_no_no",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "Th_th_th_min4_c1_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "Th_Th_th_c1_l",
+    "outputKey": "th1_no_no",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "Th_Th_th_min4_c1_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "Th_Th_Th_c1_l",
+    "outputKey": "th1_no_no",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "Th_Th_Th_min4_c1_l",
+    "outputKey": "th4_no_no",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "th_th_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "th_th_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_th_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_th_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_Th_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_Th_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "th_th_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "th_th_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Th_th_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Th_th_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Th_Th_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Th_Th_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "th_th_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "th_th_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Th_th_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Th_th_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Th_Th_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Th_Th_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "th_th_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "th_th_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Th_th_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Th_th_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Th_Th_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Th_Th_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "th_th_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "th_th_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Th_th_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Th_th_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Th_Th_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Th_Th_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "th_th_c15",
+    "outputKey": "th7_th7",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "th_th_min4_c15",
+    "outputKey": "th7_th7",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Th_th_c15",
+    "outputKey": "th7_th7",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Th_th_min4_c15",
+    "outputKey": "th7_th7",
+  },
+  {
+    "damage": "291/286",
+    "inputKey": "Th_Th_c15",
+    "outputKey": "Th7_Th6",
+  },
+  {
+    "damage": "291/286",
+    "inputKey": "Th_Th_min4_c15",
+    "outputKey": "Th7_Th6",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "th_th_c14",
+    "outputKey": "th7_th6",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "th_th_min4_c14",
+    "outputKey": "th7_th6",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "Th_th_c14",
+    "outputKey": "th7_th6",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "Th_th_min4_c14",
+    "outputKey": "th7_th6",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "Th_Th_c14",
+    "outputKey": "Th6_Th6",
+  },
+  {
+    "damage": "264/254",
+    "inputKey": "Th_Th_min4_c14",
+    "outputKey": "Th6_Th6",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "th_th_c13",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "th_th_min4_c13",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "Th_th_c13",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "Th_th_min4_c13",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "Th_Th_c13",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "240/224",
+    "inputKey": "Th_Th_min4_c13",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "240/196",
+    "inputKey": "th_th_c12",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "240/196",
+    "inputKey": "th_th_min4_c12",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "240/196",
+    "inputKey": "Th_th_c12",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "240/196",
+    "inputKey": "Th_th_min4_c12",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "240/196",
+    "inputKey": "Th_Th_c12",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "240/196",
+    "inputKey": "Th_Th_min4_c12",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "th_th_c11",
+    "outputKey": "th6_th5",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "th_th_min4_c11",
+    "outputKey": "th6_th5",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "Th_th_c11",
+    "outputKey": "th6_th5",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "Th_th_min4_c11",
+    "outputKey": "th6_th5",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "Th_Th_c11",
+    "outputKey": "th6_th5",
+  },
+  {
+    "damage": "168/156",
+    "inputKey": "Th_Th_min4_c11",
+    "outputKey": "th6_th5",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "th_th_c10",
+    "outputKey": "th6_th2",
+  },
+  {
+    "damage": "153/132",
+    "inputKey": "th_th_min4_c10",
+    "outputKey": "th6_th4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Th_th_c10",
+    "outputKey": "th6_th2",
+  },
+  {
+    "damage": "153/132",
+    "inputKey": "Th_th_min4_c10",
+    "outputKey": "th6_th4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Th_Th_c10",
+    "outputKey": "th6_th2",
+  },
+  {
+    "damage": "153/132",
+    "inputKey": "Th_Th_min4_c10",
+    "outputKey": "th6_th4",
+  },
+  {
+    "damage": "128/110",
+    "inputKey": "th_th_c9",
+    "outputKey": "th6_th1",
+  },
+  {
+    "damage": "153/110",
+    "inputKey": "th_th_min4_c9",
+    "outputKey": "th6_th4",
+  },
+  {
+    "damage": "128/110",
+    "inputKey": "Th_th_c9",
+    "outputKey": "th6_th1",
+  },
+  {
+    "damage": "153/110",
+    "inputKey": "Th_th_min4_c9",
+    "outputKey": "th6_th4",
+  },
+  {
+    "damage": "128/110",
+    "inputKey": "Th_Th_c9",
+    "outputKey": "th6_th1",
+  },
+  {
+    "damage": "153/110",
+    "inputKey": "Th_Th_min4_c9",
+    "outputKey": "th6_th4",
+  },
+  {
+    "damage": "96/90",
+    "inputKey": "th_th_c8",
+    "outputKey": "th5_th5",
+  },
+  {
+    "damage": "96/90",
+    "inputKey": "th_th_min4_c8",
+    "outputKey": "th5_th5",
+  },
+  {
+    "damage": "96/90",
+    "inputKey": "Th_th_c8",
+    "outputKey": "th5_th5",
+  },
+  {
+    "damage": "96/90",
+    "inputKey": "Th_th_min4_c8",
+    "outputKey": "th5_th5",
+  },
+  {
+    "damage": "96/90",
+    "inputKey": "Th_Th_c8",
+    "outputKey": "th5_th5",
+  },
+  {
+    "damage": "96/90",
+    "inputKey": "Th_Th_min4_c8",
+    "outputKey": "th5_th5",
+  },
+  {
+    "damage": "81/72",
+    "inputKey": "th_th_c7",
+    "outputKey": "th5_th4",
+  },
+  {
+    "damage": "81/72",
+    "inputKey": "th_th_min4_c7",
+    "outputKey": "th5_th4",
+  },
+  {
+    "damage": "81/72",
+    "inputKey": "Th_th_c7",
+    "outputKey": "th5_th4",
+  },
+  {
+    "damage": "81/72",
+    "inputKey": "Th_th_min4_c7",
+    "outputKey": "th5_th4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Th_Th_c7",
+    "outputKey": "Th4_Th4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Th_Th_min4_c7",
+    "outputKey": "Th4_Th4",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "th_th_c6",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "th_th_min4_c6",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "Th_th_c6",
+    "outputKey": "th4_Th3",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "Th_th_min4_c6",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "Th_Th_c6",
+    "outputKey": "th4_Th3",
+  },
+  {
+    "damage": "65/56",
+    "inputKey": "Th_Th_min4_c6",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "th_th_c5",
+    "outputKey": "th4_th2",
+  },
+  {
+    "damage": "65/42",
+    "inputKey": "th_th_min4_c5",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "Th_th_c5",
+    "outputKey": "Th3_th3",
+  },
+  {
+    "damage": "65/42",
+    "inputKey": "Th_th_min4_c5",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "Th_Th_c5",
+    "outputKey": "Th3_th3",
+  },
+  {
+    "damage": "65/42",
+    "inputKey": "Th_Th_min4_c5",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "33/30",
+    "inputKey": "th_th_c4",
+    "outputKey": "th3_th2",
+  },
+  {
+    "damage": "65/30",
+    "inputKey": "th_th_min4_c4",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "33/30",
+    "inputKey": "Th_th_c4",
+    "outputKey": "th3_th2",
+  },
+  {
+    "damage": "65/30",
+    "inputKey": "Th_th_min4_c4",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "33/30",
+    "inputKey": "Th_Th_c4",
+    "outputKey": "th3_th2",
+  },
+  {
+    "damage": "65/30",
+    "inputKey": "Th_Th_min4_c4",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "th_th_c3",
+    "outputKey": "th2_th1",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "th_th_min4_c3",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "Th_th_c3",
+    "outputKey": "th2_th1",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "Th_th_min4_c3",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "Th_Th_c3",
+    "outputKey": "th2_th1",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "Th_Th_min4_c3",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "th_th_c2",
+    "outputKey": "th1_th1",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "th_th_min4_c2",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "Th_th_c2",
+    "outputKey": "th1_th1",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "Th_th_min4_c2",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "Th_Th_c2",
+    "outputKey": "th1_th1",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "Th_Th_min4_c2",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "th_th_c1",
+    "outputKey": "th1_no",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "th_th_min4_c1",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Th_th_c1",
+    "outputKey": "th1_no",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "Th_th_min4_c1",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Th_Th_c1",
+    "outputKey": "th1_no",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "Th_Th_min4_c1",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "th_th_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "th_th_min4_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_th_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_th_min4_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_Th_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_Th_min4_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "th_th_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "th_th_min4_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Th_th_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Th_th_min4_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "449/434",
+    "inputKey": "Th_Th_c19_l",
+    "outputKey": "Th7_Th7",
+  },
+  {
+    "damage": "449/434",
+    "inputKey": "Th_Th_min4_c19_l",
+    "outputKey": "Th7_Th7",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "th_th_c18_l",
+    "outputKey": "th7_th7",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "th_th_min4_c18_l",
+    "outputKey": "th7_th7",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "Th_th_c18_l",
+    "outputKey": "Th7_th6",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "Th_th_min4_c18_l",
+    "outputKey": "Th7_th6",
+  },
+  {
+    "damage": "412/394",
+    "inputKey": "Th_Th_c18_l",
+    "outputKey": "Th7_Th6",
+  },
+  {
+    "damage": "412/394",
+    "inputKey": "Th_Th_min4_c18_l",
+    "outputKey": "Th7_Th6",
+  },
+  {
+    "damage": "374/356",
+    "inputKey": "th_th_c17_l",
+    "outputKey": "th7_th6",
+  },
+  {
+    "damage": "374/356",
+    "inputKey": "th_th_min4_c17_l",
+    "outputKey": "th7_th6",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "Th_th_c17_l",
+    "outputKey": "Th6_th6",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "Th_th_min4_c17_l",
+    "outputKey": "Th6_th6",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "Th_Th_c17_l",
+    "outputKey": "Th6_th6",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "Th_Th_min4_c17_l",
+    "outputKey": "Th6_th6",
+  },
+  {
+    "damage": "340/320",
+    "inputKey": "th_th_c16_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "340/320",
+    "inputKey": "th_th_min4_c16_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "340/320",
+    "inputKey": "Th_th_c16_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "340/320",
+    "inputKey": "Th_th_min4_c16_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "340/320",
+    "inputKey": "Th_Th_c16_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "340/320",
+    "inputKey": "Th_Th_min4_c16_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "340/286",
+    "inputKey": "th_th_c15_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "340/286",
+    "inputKey": "th_th_min4_c15_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "340/286",
+    "inputKey": "Th_th_c15_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "340/286",
+    "inputKey": "Th_th_min4_c15_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "340/286",
+    "inputKey": "Th_Th_c15_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "340/286",
+    "inputKey": "Th_Th_min4_c15_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "340/254",
+    "inputKey": "th_th_c14_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "340/254",
+    "inputKey": "th_th_min4_c14_l",
+    "outputKey": "th6_th6",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Th_th_c14_l",
+    "outputKey": "Th6_th5",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Th_th_min4_c14_l",
+    "outputKey": "Th6_th5",
+  },
+  {
+    "damage": "262/254",
+    "inputKey": "Th_Th_c14_l",
+    "outputKey": "Th6_Th5",
+  },
+  {
+    "damage": "262/254",
+    "inputKey": "Th_Th_min4_c14_l",
+    "outputKey": "Th6_Th5",
+  },
+  {
+    "damage": "238/224",
+    "inputKey": "th_th_c13_l",
+    "outputKey": "th6_th5",
+  },
+  {
+    "damage": "238/224",
+    "inputKey": "th_th_min4_c13_l",
+    "outputKey": "th6_th5",
+  },
+  {
+    "damage": "238/224",
+    "inputKey": "Th_th_c13_l",
+    "outputKey": "th6_th5",
+  },
+  {
+    "damage": "238/224",
+    "inputKey": "Th_th_min4_c13_l",
+    "outputKey": "th6_th5",
+  },
+  {
+    "damage": "238/224",
+    "inputKey": "Th_Th_c13_l",
+    "outputKey": "th6_th5",
+  },
+  {
+    "damage": "238/224",
+    "inputKey": "Th_Th_min4_c13_l",
+    "outputKey": "th6_th5",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "th_th_c12_l",
+    "outputKey": "th6_th3",
+  },
+  {
+    "damage": "217/196",
+    "inputKey": "th_th_min4_c12_l",
+    "outputKey": "th6_th4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "Th_th_c12_l",
+    "outputKey": "th6_th3",
+  },
+  {
+    "damage": "217/196",
+    "inputKey": "Th_th_min4_c12_l",
+    "outputKey": "th6_th4",
+  },
+  {
+    "damage": "200/196",
+    "inputKey": "Th_Th_c12_l",
+    "outputKey": "th6_th3",
+  },
+  {
+    "damage": "217/196",
+    "inputKey": "Th_Th_min4_c12_l",
+    "outputKey": "th6_th4",
+  },
+  {
+    "damage": "181/156",
+    "inputKey": "th_th_c11_l",
+    "outputKey": "th6_th1",
+  },
+  {
+    "damage": "217/156",
+    "inputKey": "th_th_min4_c11_l",
+    "outputKey": "th6_th4",
+  },
+  {
+    "damage": "181/156",
+    "inputKey": "Th_th_c11_l",
+    "outputKey": "th6_th1",
+  },
+  {
+    "damage": "217/156",
+    "inputKey": "Th_th_min4_c11_l",
+    "outputKey": "th6_th4",
+  },
+  {
+    "damage": "181/156",
+    "inputKey": "Th_Th_c11_l",
+    "outputKey": "th6_th1",
+  },
+  {
+    "damage": "217/156",
+    "inputKey": "Th_Th_min4_c11_l",
+    "outputKey": "th6_th4",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "th_th_c10_l",
+    "outputKey": "th5_th5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "th_th_min4_c10_l",
+    "outputKey": "th5_th5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "Th_th_c10_l",
+    "outputKey": "th5_th5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "Th_th_min4_c10_l",
+    "outputKey": "th5_th5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "Th_Th_c10_l",
+    "outputKey": "th5_th5",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "Th_Th_min4_c10_l",
+    "outputKey": "th5_th5",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "th_th_c9_l",
+    "outputKey": "th5_th4",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "th_th_min4_c9_l",
+    "outputKey": "th5_th4",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "Th_th_c9_l",
+    "outputKey": "th5_th4",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "Th_th_min4_c9_l",
+    "outputKey": "th5_th4",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "Th_Th_c9_l",
+    "outputKey": "th5_th4",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "Th_Th_min4_c9_l",
+    "outputKey": "th5_th4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "th_th_c8_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "th_th_min4_c8_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_th_c8_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_th_min4_c8_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_Th_c8_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Th_Th_min4_c8_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "75/72",
+    "inputKey": "th_th_c7_l",
+    "outputKey": "th4_th3",
+  },
+  {
+    "damage": "92/72",
+    "inputKey": "th_th_min4_c7_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "75/72",
+    "inputKey": "Th_th_c7_l",
+    "outputKey": "th4_th3",
+  },
+  {
+    "damage": "92/72",
+    "inputKey": "Th_th_min4_c7_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "75/72",
+    "inputKey": "Th_Th_c7_l",
+    "outputKey": "th4_th3",
+  },
+  {
+    "damage": "92/72",
+    "inputKey": "Th_Th_min4_c7_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "th_th_c6_l",
+    "outputKey": "th3_th3",
+  },
+  {
+    "damage": "92/56",
+    "inputKey": "th_th_min4_c6_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "Th_th_c6_l",
+    "outputKey": "th3_th3",
+  },
+  {
+    "damage": "92/56",
+    "inputKey": "Th_th_min4_c6_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "Th_Th_c6_l",
+    "outputKey": "th3_th3",
+  },
+  {
+    "damage": "92/56",
+    "inputKey": "Th_Th_min4_c6_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "47/42",
+    "inputKey": "th_th_c5_l",
+    "outputKey": "th3_th2",
+  },
+  {
+    "damage": "92/42",
+    "inputKey": "th_th_min4_c5_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "47/42",
+    "inputKey": "Th_th_c5_l",
+    "outputKey": "th3_th2",
+  },
+  {
+    "damage": "92/42",
+    "inputKey": "Th_th_min4_c5_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "47/42",
+    "inputKey": "Th_Th_c5_l",
+    "outputKey": "th3_th2",
+  },
+  {
+    "damage": "92/42",
+    "inputKey": "Th_Th_min4_c5_l",
+    "outputKey": "th4_th4",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "th_th_c4_l",
+    "outputKey": "th2_th2",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "th_th_min4_c4_l",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Th_th_c4_l",
+    "outputKey": "th2_Th1",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "Th_th_min4_c4_l",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Th_Th_c4_l",
+    "outputKey": "th2_Th1",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "Th_Th_min4_c4_l",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "th_th_c3_l",
+    "outputKey": "th1_th1",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "th_th_min4_c3_l",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Th_th_c3_l",
+    "outputKey": "th1_th1",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "Th_th_min4_c3_l",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Th_Th_c3_l",
+    "outputKey": "th1_th1",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "Th_Th_min4_c3_l",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "th_th_c2_l",
+    "outputKey": "th1_th1",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "th_th_min4_c2_l",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Th_th_c2_l",
+    "outputKey": "th1_th1",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "Th_th_min4_c2_l",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Th_Th_c2_l",
+    "outputKey": "th1_th1",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "Th_Th_min4_c2_l",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "th_th_c1_l",
+    "outputKey": "th1_no",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "th_th_min4_c1_l",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "Th_th_c1_l",
+    "outputKey": "th1_no",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "Th_th_min4_c1_l",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "Th_Th_c1_l",
+    "outputKey": "th1_no",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "Th_Th_min4_c1_l",
+    "outputKey": "th4_no",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "th_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "th_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "th_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "th_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Th_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Th_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "th_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "th_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Th_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Th_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "th_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "th_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Th_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Th_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "th_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "th_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Th_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Th_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "th_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "th_min4_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "Th_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "Th_min4_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "th_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "th_min4_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "Th_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "Th_min4_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "th_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "th_min4_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "Th_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "Th_min4_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "th_c12",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "th_min4_c12",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "Th_c12",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "Th_min4_c12",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/156",
+    "inputKey": "th_c11",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/156",
+    "inputKey": "th_min4_c11",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/156",
+    "inputKey": "Th_c11",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/156",
+    "inputKey": "Th_min4_c11",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/132",
+    "inputKey": "th_c10",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/132",
+    "inputKey": "th_min4_c10",
+    "outputKey": "",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Th_c10",
+    "outputKey": "Th7",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Th_min4_c10",
+    "outputKey": "Th7",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "th_c9",
+    "outputKey": "th7",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "th_min4_c9",
+    "outputKey": "th7",
+  },
+  {
+    "damage": "110/110",
+    "inputKey": "Th_c9",
+    "outputKey": "Th6",
+  },
+  {
+    "damage": "110/110",
+    "inputKey": "Th_min4_c9",
+    "outputKey": "Th6",
+  },
+  {
+    "damage": "100/90",
+    "inputKey": "th_c8",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "100/90",
+    "inputKey": "th_min4_c8",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "100/90",
+    "inputKey": "Th_c8",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "100/90",
+    "inputKey": "Th_min4_c8",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "100/72",
+    "inputKey": "th_c7",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "100/72",
+    "inputKey": "th_min4_c7",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "100/72",
+    "inputKey": "Th_c7",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "100/72",
+    "inputKey": "Th_min4_c7",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "100/56",
+    "inputKey": "th_c6",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "100/56",
+    "inputKey": "th_min4_c6",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "100/56",
+    "inputKey": "Th_c6",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "100/56",
+    "inputKey": "Th_min4_c6",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "100/42",
+    "inputKey": "th_c5",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "100/42",
+    "inputKey": "th_min4_c5",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "Th_c5",
+    "outputKey": "Th5",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "Th_min4_c5",
+    "outputKey": "Th5",
+  },
+  {
+    "damage": "40/30",
+    "inputKey": "th_c4",
+    "outputKey": "th5",
+  },
+  {
+    "damage": "40/30",
+    "inputKey": "th_min4_c4",
+    "outputKey": "th5",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Th_c4",
+    "outputKey": "Th4",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Th_min4_c4",
+    "outputKey": "Th4",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "th_c3",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "th_min4_c3",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "Th_c3",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "27/20",
+    "inputKey": "Th_min4_c3",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "17/12",
+    "inputKey": "th_c2",
+    "outputKey": "th3",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "th_min4_c2",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "17/12",
+    "inputKey": "Th_c2",
+    "outputKey": "th3",
+  },
+  {
+    "damage": "27/12",
+    "inputKey": "Th_min4_c2",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "th_c1",
+    "outputKey": "th1",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "th_min4_c1",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Th_c1",
+    "outputKey": "th1",
+  },
+  {
+    "damage": "27/6",
+    "inputKey": "Th_min4_c1",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "th_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "th_min4_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Th_min4_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "th_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "th_min4_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Th_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Th_min4_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "th_c18_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "th_min4_c18_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Th_c18_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Th_min4_c18_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "th_c17_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "th_min4_c17_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Th_c17_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Th_min4_c17_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "th_c16_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "th_min4_c16_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Th_c16_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Th_min4_c16_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "th_c15_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "th_min4_c15_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "Th_c15_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "Th_min4_c15_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "th_c14_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "th_min4_c14_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "Th_c14_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "Th_min4_c14_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "th_c13_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "th_min4_c13_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "Th_c13_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "Th_min4_c13_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "th_c12_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "th_min4_c12_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "198/196",
+    "inputKey": "Th_c12_l",
+    "outputKey": "Th7",
+  },
+  {
+    "damage": "198/196",
+    "inputKey": "Th_min4_c12_l",
+    "outputKey": "Th7",
+  },
+  {
+    "damage": "180/156",
+    "inputKey": "th_c11_l",
+    "outputKey": "th7",
+  },
+  {
+    "damage": "180/156",
+    "inputKey": "th_min4_c11_l",
+    "outputKey": "th7",
+  },
+  {
+    "damage": "165/156",
+    "inputKey": "Th_c11_l",
+    "outputKey": "Th6",
+  },
+  {
+    "damage": "165/156",
+    "inputKey": "Th_min4_c11_l",
+    "outputKey": "Th6",
+  },
+  {
+    "damage": "150/132",
+    "inputKey": "th_c10_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/132",
+    "inputKey": "th_min4_c10_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/132",
+    "inputKey": "Th_c10_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/132",
+    "inputKey": "Th_min4_c10_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/110",
+    "inputKey": "th_c9_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/110",
+    "inputKey": "th_min4_c9_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/110",
+    "inputKey": "Th_c9_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/110",
+    "inputKey": "Th_min4_c9_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/90",
+    "inputKey": "th_c8_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/90",
+    "inputKey": "th_min4_c8_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/90",
+    "inputKey": "Th_c8_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/90",
+    "inputKey": "Th_min4_c8_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/72",
+    "inputKey": "th_c7_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/72",
+    "inputKey": "th_min4_c7_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/72",
+    "inputKey": "Th_c7_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "150/72",
+    "inputKey": "Th_min4_c7_l",
+    "outputKey": "th6",
+  },
+  {
+    "damage": "60/56",
+    "inputKey": "th_c6_l",
+    "outputKey": "th5",
+  },
+  {
+    "damage": "60/56",
+    "inputKey": "th_min4_c6_l",
+    "outputKey": "th5",
+  },
+  {
+    "damage": "60/56",
+    "inputKey": "Th_c6_l",
+    "outputKey": "th5",
+  },
+  {
+    "damage": "60/56",
+    "inputKey": "Th_min4_c6_l",
+    "outputKey": "th5",
+  },
+  {
+    "damage": "60/42",
+    "inputKey": "th_c5_l",
+    "outputKey": "th5",
+  },
+  {
+    "damage": "60/42",
+    "inputKey": "th_min4_c5_l",
+    "outputKey": "th5",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "Th_c5_l",
+    "outputKey": "Th4",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "Th_min4_c5_l",
+    "outputKey": "Th4",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "th_c4_l",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "th_min4_c4_l",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "Th_c4_l",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "41/30",
+    "inputKey": "Th_min4_c4_l",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "26/20",
+    "inputKey": "th_c3_l",
+    "outputKey": "th3",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "th_min4_c3_l",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "26/20",
+    "inputKey": "Th_c3_l",
+    "outputKey": "th3",
+  },
+  {
+    "damage": "41/20",
+    "inputKey": "Th_min4_c3_l",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "th_c2_l",
+    "outputKey": "th2",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "th_min4_c2_l",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "Th_c2_l",
+    "outputKey": "th2",
+  },
+  {
+    "damage": "41/12",
+    "inputKey": "Th_min4_c2_l",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "th_c1_l",
+    "outputKey": "th1",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "th_min4_c1_l",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "9/6",
+    "inputKey": "Th_c1_l",
+    "outputKey": "th1",
+  },
+  {
+    "damage": "41/6",
+    "inputKey": "Th_min4_c1_l",
+    "outputKey": "th4",
+  },
+  {
+    "damage": "504/476",
+    "inputKey": "sq_sq_sq_sq_c20",
+    "outputKey": "sq7_sq7_sq7_sq7",
+  },
+  {
+    "damage": "504/476",
+    "inputKey": "sq_sq_sq_sq_min4_c20",
+    "outputKey": "sq7_sq7_sq7_sq7",
+  },
+  {
+    "damage": "489/476",
+    "inputKey": "Sq_sq_sq_sq_c20",
+    "outputKey": "sq7_sq7_sq7_Sq6",
+  },
+  {
+    "damage": "489/476",
+    "inputKey": "Sq_sq_sq_sq_min4_c20",
+    "outputKey": "sq7_sq7_sq7_Sq6",
+  },
+  {
+    "damage": "478/476",
+    "inputKey": "Sq_Sq_sq_sq_c20",
+    "outputKey": "Sq7_sq7_Sq6_sq6",
+  },
+  {
+    "damage": "478/476",
+    "inputKey": "Sq_Sq_sq_sq_min4_c20",
+    "outputKey": "Sq7_sq7_Sq6_sq6",
+  },
+  {
+    "damage": "492/476",
+    "inputKey": "Sq_Sq_Sq_sq_c20",
+    "outputKey": "Sq7_sq7_Sq6_Sq6",
+  },
+  {
+    "damage": "492/476",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c20",
+    "outputKey": "Sq7_sq7_Sq6_Sq6",
+  },
+  {
+    "damage": "477/476",
+    "inputKey": "Sq_Sq_Sq_Sq_c20",
+    "outputKey": "Sq7_Sq6_Sq6_Sq6",
+  },
+  {
+    "damage": "477/476",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c20",
+    "outputKey": "Sq7_Sq6_Sq6_Sq6",
+  },
+  {
+    "damage": "444/434",
+    "inputKey": "sq_sq_sq_sq_c19",
+    "outputKey": "sq7_sq7_sq6_sq6",
+  },
+  {
+    "damage": "444/434",
+    "inputKey": "sq_sq_sq_sq_min4_c19",
+    "outputKey": "sq7_sq7_sq6_sq6",
+  },
+  {
+    "damage": "434/434",
+    "inputKey": "Sq_sq_sq_sq_c19",
+    "outputKey": "Sq7_sq6_sq6_sq6",
+  },
+  {
+    "damage": "434/434",
+    "inputKey": "Sq_sq_sq_sq_min4_c19",
+    "outputKey": "Sq7_sq6_sq6_sq6",
+  },
+  {
+    "damage": "443/434",
+    "inputKey": "Sq_Sq_sq_sq_c19",
+    "outputKey": "sq7_Sq6_Sq6_sq6",
+  },
+  {
+    "damage": "443/434",
+    "inputKey": "Sq_Sq_sq_sq_min4_c19",
+    "outputKey": "sq7_Sq6_Sq6_sq6",
+  },
+  {
+    "damage": "443/434",
+    "inputKey": "Sq_Sq_Sq_sq_c19",
+    "outputKey": "sq7_Sq6_Sq6_sq6",
+  },
+  {
+    "damage": "443/434",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c19",
+    "outputKey": "sq7_Sq6_Sq6_sq6",
+  },
+  {
+    "damage": "442/434",
+    "inputKey": "Sq_Sq_Sq_Sq_c19",
+    "outputKey": "Sq6_Sq6_Sq6_Sq6",
+  },
+  {
+    "damage": "442/434",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c19",
+    "outputKey": "Sq6_Sq6_Sq6_Sq6",
+  },
+  {
+    "damage": "414/394",
+    "inputKey": "sq_sq_sq_sq_c18",
+    "outputKey": "sq7_sq6_sq6_sq6",
+  },
+  {
+    "damage": "414/394",
+    "inputKey": "sq_sq_sq_sq_min4_c18",
+    "outputKey": "sq7_sq6_sq6_sq6",
+  },
+  {
+    "damage": "399/394",
+    "inputKey": "Sq_sq_sq_sq_c18",
+    "outputKey": "Sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "399/394",
+    "inputKey": "Sq_sq_sq_sq_min4_c18",
+    "outputKey": "Sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "399/394",
+    "inputKey": "Sq_Sq_sq_sq_c18",
+    "outputKey": "Sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "399/394",
+    "inputKey": "Sq_Sq_sq_sq_min4_c18",
+    "outputKey": "Sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "399/394",
+    "inputKey": "Sq_Sq_Sq_sq_c18",
+    "outputKey": "Sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "399/394",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c18",
+    "outputKey": "Sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "399/394",
+    "inputKey": "Sq_Sq_Sq_Sq_c18",
+    "outputKey": "Sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "399/394",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c18",
+    "outputKey": "Sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "384/356",
+    "inputKey": "sq_sq_sq_sq_c17",
+    "outputKey": "sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "384/356",
+    "inputKey": "sq_sq_sq_sq_min4_c17",
+    "outputKey": "sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "384/356",
+    "inputKey": "Sq_sq_sq_sq_c17",
+    "outputKey": "sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "384/356",
+    "inputKey": "Sq_sq_sq_sq_min4_c17",
+    "outputKey": "sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "384/356",
+    "inputKey": "Sq_Sq_sq_sq_c17",
+    "outputKey": "sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "384/356",
+    "inputKey": "Sq_Sq_sq_sq_min4_c17",
+    "outputKey": "sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "359/356",
+    "inputKey": "Sq_Sq_Sq_sq_c17",
+    "outputKey": "Sq6_Sq6_sq6_Sq5",
+  },
+  {
+    "damage": "359/356",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c17",
+    "outputKey": "Sq6_Sq6_sq6_Sq5",
+  },
+  {
+    "damage": "359/356",
+    "inputKey": "Sq_Sq_Sq_Sq_c17",
+    "outputKey": "Sq6_Sq6_sq6_Sq5",
+  },
+  {
+    "damage": "359/356",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c17",
+    "outputKey": "Sq6_Sq6_sq6_Sq5",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "sq_sq_sq_sq_c16",
+    "outputKey": "sq6_sq6_sq6_sq5",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "sq_sq_sq_sq_min4_c16",
+    "outputKey": "sq6_sq6_sq6_sq5",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "Sq_sq_sq_sq_c16",
+    "outputKey": "sq6_sq6_sq6_sq5",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "Sq_sq_sq_sq_min4_c16",
+    "outputKey": "sq6_sq6_sq6_sq5",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "Sq_Sq_sq_sq_c16",
+    "outputKey": "sq6_sq6_sq6_sq5",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "Sq_Sq_sq_sq_min4_c16",
+    "outputKey": "sq6_sq6_sq6_sq5",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "Sq_Sq_Sq_sq_c16",
+    "outputKey": "sq6_sq6_sq6_sq5",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c16",
+    "outputKey": "sq6_sq6_sq6_sq5",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "Sq_Sq_Sq_Sq_c16",
+    "outputKey": "sq6_sq6_sq6_sq5",
+  },
+  {
+    "damage": "324/320",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c16",
+    "outputKey": "sq6_sq6_sq6_sq5",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "sq_sq_sq_sq_c15",
+    "outputKey": "sq6_sq6_sq6_no",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "sq_sq_sq_sq_min4_c15",
+    "outputKey": "sq6_sq6_sq6_no",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Sq_sq_sq_sq_c15",
+    "outputKey": "sq6_sq6_sq6_no",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Sq_sq_sq_sq_min4_c15",
+    "outputKey": "sq6_sq6_sq6_no",
+  },
+  {
+    "damage": "293/286",
+    "inputKey": "Sq_Sq_sq_sq_c15",
+    "outputKey": "Sq6_Sq6_sq5_sq5",
+  },
+  {
+    "damage": "293/286",
+    "inputKey": "Sq_Sq_sq_sq_min4_c15",
+    "outputKey": "Sq6_Sq6_sq5_sq5",
+  },
+  {
+    "damage": "291/286",
+    "inputKey": "Sq_Sq_Sq_sq_c15",
+    "outputKey": "Sq6_sq6_Sq5_Sq5",
+  },
+  {
+    "damage": "291/286",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c15",
+    "outputKey": "Sq6_sq6_Sq5_Sq5",
+  },
+  {
+    "damage": "291/286",
+    "inputKey": "Sq_Sq_Sq_Sq_c15",
+    "outputKey": "Sq6_sq6_Sq5_Sq5",
+  },
+  {
+    "damage": "291/286",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c15",
+    "outputKey": "Sq6_sq6_Sq5_Sq5",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "sq_sq_sq_sq_c14",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "sq_sq_sq_sq_min4_c14",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "Sq_sq_sq_sq_c14",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "Sq_sq_sq_sq_min4_c14",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "Sq_Sq_sq_sq_c14",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "Sq_Sq_sq_sq_min4_c14",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "Sq_Sq_Sq_sq_c14",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c14",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "Sq_Sq_Sq_Sq_c14",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "254/254",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c14",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "sq_sq_sq_sq_c13",
+    "outputKey": "sq6_sq6_sq5_no",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "sq_sq_sq_sq_min4_c13",
+    "outputKey": "sq6_sq6_sq5_no",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Sq_sq_sq_sq_c13",
+    "outputKey": "sq6_sq6_sq5_no",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Sq_sq_sq_sq_min4_c13",
+    "outputKey": "sq6_sq6_sq5_no",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "Sq_Sq_sq_sq_c13",
+    "outputKey": "Sq6_Sq5_sq5_sq5",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "Sq_Sq_sq_sq_min4_c13",
+    "outputKey": "Sq6_Sq5_sq5_sq5",
+  },
+  {
+    "damage": "231/224",
+    "inputKey": "Sq_Sq_Sq_sq_c13",
+    "outputKey": "Sq6_Sq5_Sq5_sq5",
+  },
+  {
+    "damage": "231/224",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c13",
+    "outputKey": "Sq6_Sq5_Sq5_sq5",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "Sq_Sq_Sq_Sq_c13",
+    "outputKey": "Sq6_Sq5_Sq5_Sq4",
+  },
+  {
+    "damage": "225/224",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c13",
+    "outputKey": "Sq6_Sq5_Sq5_Sq4",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "sq_sq_sq_sq_c12",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "sq_sq_sq_sq_min4_c12",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "Sq_sq_sq_sq_c12",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "Sq_sq_sq_sq_min4_c12",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "Sq_Sq_sq_sq_c12",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "Sq_Sq_sq_sq_min4_c12",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "Sq_Sq_Sq_sq_c12",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c12",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "Sq_Sq_Sq_Sq_c12",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c12",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "sq_sq_sq_sq_c11",
+    "outputKey": "sq6_sq5_sq4_no",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "sq_sq_sq_sq_min4_c11",
+    "outputKey": "sq6_sq5_sq4_no",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "Sq_sq_sq_sq_c11",
+    "outputKey": "sq6_sq5_sq4_no",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "Sq_sq_sq_sq_min4_c11",
+    "outputKey": "sq6_sq5_sq4_no",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "Sq_Sq_sq_sq_c11",
+    "outputKey": "Sq5_Sq5_sq5_sq5",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "Sq_Sq_sq_sq_min4_c11",
+    "outputKey": "Sq5_Sq5_sq5_sq5",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "Sq_Sq_Sq_sq_c11",
+    "outputKey": "Sq5_Sq5_sq5_sq5",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c11",
+    "outputKey": "Sq5_Sq5_sq5_sq5",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "Sq_Sq_Sq_Sq_c11",
+    "outputKey": "Sq5_Sq5_Sq5_Sq4",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c11",
+    "outputKey": "Sq5_Sq5_Sq5_Sq4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "sq_sq_sq_sq_c10",
+    "outputKey": "sq5_sq5_sq5_sq4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "sq_sq_sq_sq_min4_c10",
+    "outputKey": "sq5_sq5_sq5_sq4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "Sq_sq_sq_sq_c10",
+    "outputKey": "sq5_sq5_sq5_sq4",
+  },
+  {
+    "damage": "134/132",
+    "inputKey": "Sq_sq_sq_sq_min4_c10",
+    "outputKey": "sq5_sq5_sq5_sq4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_sq_sq_c10",
+    "outputKey": "sq5_sq5_Sq4_Sq4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_sq_sq_min4_c10",
+    "outputKey": "sq5_sq5_Sq4_Sq4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_Sq_sq_c10",
+    "outputKey": "sq5_sq5_Sq4_Sq4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c10",
+    "outputKey": "sq5_sq5_Sq4_Sq4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_Sq_Sq_c10",
+    "outputKey": "Sq5_Sq4_Sq4_Sq4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c10",
+    "outputKey": "Sq5_Sq4_Sq4_Sq4",
+  },
+  {
+    "damage": "112/110",
+    "inputKey": "sq_sq_sq_sq_c9",
+    "outputKey": "sq5_sq4_sq4_sq4",
+  },
+  {
+    "damage": "112/110",
+    "inputKey": "sq_sq_sq_sq_min4_c9",
+    "outputKey": "sq5_sq4_sq4_sq4",
+  },
+  {
+    "damage": "112/110",
+    "inputKey": "Sq_sq_sq_sq_c9",
+    "outputKey": "sq5_sq4_sq4_sq4",
+  },
+  {
+    "damage": "112/110",
+    "inputKey": "Sq_sq_sq_sq_min4_c9",
+    "outputKey": "sq5_sq4_sq4_sq4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Sq_Sq_sq_sq_c9",
+    "outputKey": "Sq4_Sq4_sq4_sq4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Sq_Sq_sq_sq_min4_c9",
+    "outputKey": "Sq4_Sq4_sq4_sq4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Sq_Sq_Sq_sq_c9",
+    "outputKey": "Sq4_Sq4_sq4_sq4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c9",
+    "outputKey": "Sq4_Sq4_sq4_sq4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Sq_Sq_Sq_Sq_c9",
+    "outputKey": "Sq4_Sq4_sq4_sq4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c9",
+    "outputKey": "Sq4_Sq4_sq4_sq4",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "sq_sq_sq_sq_c8",
+    "outputKey": "sq4_sq4_sq4_sq3",
+  },
+  {
+    "damage": "101/90",
+    "inputKey": "sq_sq_sq_sq_min4_c8",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "Sq_sq_sq_sq_c8",
+    "outputKey": "sq4_sq4_sq4_sq3",
+  },
+  {
+    "damage": "101/90",
+    "inputKey": "Sq_sq_sq_sq_min4_c8",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "Sq_Sq_sq_sq_c8",
+    "outputKey": "sq4_sq4_sq4_sq3",
+  },
+  {
+    "damage": "101/90",
+    "inputKey": "Sq_Sq_sq_sq_min4_c8",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Sq_Sq_Sq_sq_c8",
+    "outputKey": "Sq4_Sq4_Sq3_sq3",
+  },
+  {
+    "damage": "101/90",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c8",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "94/90",
+    "inputKey": "Sq_Sq_Sq_Sq_c8",
+    "outputKey": "Sq4_Sq4_Sq3_Sq3",
+  },
+  {
+    "damage": "101/90",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c8",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "75/72",
+    "inputKey": "sq_sq_sq_sq_c7",
+    "outputKey": "sq4_sq4_sq3_sq2",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "sq_sq_sq_sq_min4_c7",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "Sq_sq_sq_sq_c7",
+    "outputKey": "Sq4_sq3_sq3_sq3",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "Sq_sq_sq_sq_min4_c7",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "Sq_Sq_sq_sq_c7",
+    "outputKey": "sq4_Sq3_Sq3_sq3",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "Sq_Sq_sq_sq_min4_c7",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "Sq_Sq_Sq_sq_c7",
+    "outputKey": "sq4_Sq3_Sq3_sq3",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c7",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "74/72",
+    "inputKey": "Sq_Sq_Sq_Sq_c7",
+    "outputKey": "sq4_Sq3_Sq3_sq3",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c7",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "sq_sq_sq_sq_c6",
+    "outputKey": "sq3_sq3_sq3_sq3",
+  },
+  {
+    "damage": "76/56",
+    "inputKey": "sq_sq_sq_sq_min4_c6",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "Sq_sq_sq_sq_c6",
+    "outputKey": "sq3_sq3_sq3_Sq2",
+  },
+  {
+    "damage": "76/56",
+    "inputKey": "Sq_sq_sq_sq_min4_c6",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "Sq_Sq_sq_sq_c6",
+    "outputKey": "sq3_sq3_sq3_Sq2",
+  },
+  {
+    "damage": "76/56",
+    "inputKey": "Sq_Sq_sq_sq_min4_c6",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "Sq_Sq_Sq_sq_c6",
+    "outputKey": "Sq3_sq3_Sq2_Sq2",
+  },
+  {
+    "damage": "76/56",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c6",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "Sq_Sq_Sq_Sq_c6",
+    "outputKey": "Sq3_sq3_Sq2_Sq2",
+  },
+  {
+    "damage": "76/56",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c6",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "sq_sq_sq_sq_c5",
+    "outputKey": "sq3_sq2_sq2_sq2",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "sq_sq_sq_sq_min4_c5",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "Sq_sq_sq_sq_c5",
+    "outputKey": "sq3_sq2_sq2_sq2",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "Sq_sq_sq_sq_min4_c5",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "Sq_Sq_sq_sq_c5",
+    "outputKey": "Sq2_Sq2_sq2_sq2",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "Sq_Sq_sq_sq_min4_c5",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "Sq_Sq_Sq_sq_c5",
+    "outputKey": "Sq2_Sq2_sq2_sq2",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c5",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "42/42",
+    "inputKey": "Sq_Sq_Sq_Sq_c5",
+    "outputKey": "Sq2_Sq2_Sq2_Sq1",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c5",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "sq_sq_sq_sq_c4",
+    "outputKey": "sq2_sq2_sq2_sq1",
+  },
+  {
+    "damage": "51/30",
+    "inputKey": "sq_sq_sq_sq_min4_c4",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_sq_sq_sq_c4",
+    "outputKey": "sq2_sq2_Sq1_sq1",
+  },
+  {
+    "damage": "51/30",
+    "inputKey": "Sq_sq_sq_sq_min4_c4",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_Sq_sq_sq_c4",
+    "outputKey": "sq2_sq2_Sq1_sq1",
+  },
+  {
+    "damage": "51/30",
+    "inputKey": "Sq_Sq_sq_sq_min4_c4",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_Sq_Sq_sq_c4",
+    "outputKey": "sq2_sq2_Sq1_sq1",
+  },
+  {
+    "damage": "51/30",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c4",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_Sq_Sq_Sq_c4",
+    "outputKey": "Sq2_Sq1_Sq1_Sq1",
+  },
+  {
+    "damage": "51/30",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c4",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "sq_sq_sq_sq_c3",
+    "outputKey": "sq1_sq1_sq1_sq1",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "sq_sq_sq_sq_min4_c3",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "Sq_sq_sq_sq_c3",
+    "outputKey": "sq1_sq1_sq1_sq1",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_sq_sq_sq_min4_c3",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "Sq_Sq_sq_sq_c3",
+    "outputKey": "sq1_sq1_sq1_sq1",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_Sq_sq_sq_min4_c3",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "Sq_Sq_Sq_sq_c3",
+    "outputKey": "sq1_sq1_sq1_sq1",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c3",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "Sq_Sq_Sq_Sq_c3",
+    "outputKey": "sq1_sq1_sq1_sq1",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c3",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "sq_sq_sq_sq_c2",
+    "outputKey": "sq1_sq1_sq1_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "sq_sq_sq_sq_min4_c2",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "Sq_sq_sq_sq_c2",
+    "outputKey": "sq1_sq1_sq1_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Sq_sq_sq_sq_min4_c2",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "Sq_Sq_sq_sq_c2",
+    "outputKey": "Sq1_Sq1_no_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Sq_Sq_sq_sq_min4_c2",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "Sq_Sq_Sq_sq_c2",
+    "outputKey": "Sq1_Sq1_no_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c2",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "Sq_Sq_Sq_Sq_c2",
+    "outputKey": "Sq1_Sq1_no_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c2",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "sq_sq_sq_sq_c1",
+    "outputKey": "sq1_sq1_no_no",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "sq_sq_sq_sq_min4_c1",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "Sq_sq_sq_sq_c1",
+    "outputKey": "sq1_sq1_no_no",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "Sq_sq_sq_sq_min4_c1",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "Sq_Sq_sq_sq_c1",
+    "outputKey": "sq1_sq1_no_no",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "Sq_Sq_sq_sq_min4_c1",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "Sq_Sq_Sq_sq_c1",
+    "outputKey": "sq1_sq1_no_no",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c1",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "Sq_Sq_Sq_Sq_c1",
+    "outputKey": "sq1_sq1_no_no",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c1",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "544/476",
+    "inputKey": "sq_sq_sq_sq_c20_l",
+    "outputKey": "sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "544/476",
+    "inputKey": "sq_sq_sq_sq_min4_c20_l",
+    "outputKey": "sq6_sq6_sq6_sq6",
+  },
+  {
+    "damage": "480/476",
+    "inputKey": "Sq_sq_sq_sq_c20_l",
+    "outputKey": "Sq6_sq6_sq6_sq5",
+  },
+  {
+    "damage": "480/476",
+    "inputKey": "Sq_sq_sq_sq_min4_c20_l",
+    "outputKey": "Sq6_sq6_sq6_sq5",
+  },
+  {
+    "damage": "489/476",
+    "inputKey": "Sq_Sq_sq_sq_c20_l",
+    "outputKey": "Sq6_sq6_sq6_Sq5",
+  },
+  {
+    "damage": "489/476",
+    "inputKey": "Sq_Sq_sq_sq_min4_c20_l",
+    "outputKey": "Sq6_sq6_sq6_Sq5",
+  },
+  {
+    "damage": "489/476",
+    "inputKey": "Sq_Sq_Sq_sq_c20_l",
+    "outputKey": "Sq6_sq6_sq6_Sq5",
+  },
+  {
+    "damage": "489/476",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c20_l",
+    "outputKey": "Sq6_sq6_sq6_Sq5",
+  },
+  {
+    "damage": "489/476",
+    "inputKey": "Sq_Sq_Sq_Sq_c20_l",
+    "outputKey": "Sq6_sq6_sq6_Sq5",
+  },
+  {
+    "damage": "489/476",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c20_l",
+    "outputKey": "Sq6_sq6_sq6_Sq5",
+  },
+  {
+    "damage": "445/434",
+    "inputKey": "sq_sq_sq_sq_c19_l",
+    "outputKey": "sq6_sq6_sq6_sq4",
+  },
+  {
+    "damage": "445/434",
+    "inputKey": "sq_sq_sq_sq_min4_c19_l",
+    "outputKey": "sq6_sq6_sq6_sq4",
+  },
+  {
+    "damage": "445/434",
+    "inputKey": "Sq_sq_sq_sq_c19_l",
+    "outputKey": "sq6_sq6_sq6_sq4",
+  },
+  {
+    "damage": "445/434",
+    "inputKey": "Sq_sq_sq_sq_min4_c19_l",
+    "outputKey": "sq6_sq6_sq6_sq4",
+  },
+  {
+    "damage": "445/434",
+    "inputKey": "Sq_Sq_sq_sq_c19_l",
+    "outputKey": "sq6_sq6_sq6_sq4",
+  },
+  {
+    "damage": "445/434",
+    "inputKey": "Sq_Sq_sq_sq_min4_c19_l",
+    "outputKey": "sq6_sq6_sq6_sq4",
+  },
+  {
+    "damage": "445/434",
+    "inputKey": "Sq_Sq_Sq_sq_c19_l",
+    "outputKey": "sq6_sq6_sq6_sq4",
+  },
+  {
+    "damage": "445/434",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c19_l",
+    "outputKey": "sq6_sq6_sq6_sq4",
+  },
+  {
+    "damage": "445/434",
+    "inputKey": "Sq_Sq_Sq_Sq_c19_l",
+    "outputKey": "sq6_sq6_sq6_sq4",
+  },
+  {
+    "damage": "445/434",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c19_l",
+    "outputKey": "sq6_sq6_sq6_sq4",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "sq_sq_sq_sq_c18_l",
+    "outputKey": "sq6_sq6_sq6_no",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "sq_sq_sq_sq_min4_c18_l",
+    "outputKey": "sq6_sq6_sq6_no",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "Sq_sq_sq_sq_c18_l",
+    "outputKey": "Sq6_sq6_sq5_sq5",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "Sq_sq_sq_sq_min4_c18_l",
+    "outputKey": "Sq6_sq6_sq5_sq5",
+  },
+  {
+    "damage": "404/394",
+    "inputKey": "Sq_Sq_sq_sq_c18_l",
+    "outputKey": "Sq6_sq6_Sq5_sq5",
+  },
+  {
+    "damage": "404/394",
+    "inputKey": "Sq_Sq_sq_sq_min4_c18_l",
+    "outputKey": "Sq6_sq6_Sq5_sq5",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "Sq_Sq_Sq_sq_c18_l",
+    "outputKey": "Sq6_sq6_Sq5_Sq4",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c18_l",
+    "outputKey": "Sq6_sq6_Sq5_Sq4",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "Sq_Sq_Sq_Sq_c18_l",
+    "outputKey": "Sq6_sq6_Sq5_Sq4",
+  },
+  {
+    "damage": "395/394",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c18_l",
+    "outputKey": "Sq6_sq6_Sq5_Sq4",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "sq_sq_sq_sq_c17_l",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "sq_sq_sq_sq_min4_c17_l",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Sq_sq_sq_sq_c17_l",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Sq_sq_sq_sq_min4_c17_l",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Sq_Sq_sq_sq_c17_l",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Sq_Sq_sq_sq_min4_c17_l",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Sq_Sq_Sq_sq_c17_l",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c17_l",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Sq_Sq_Sq_Sq_c17_l",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "360/356",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c17_l",
+    "outputKey": "sq6_sq6_sq5_sq4",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "sq_sq_sq_sq_c16_l",
+    "outputKey": "sq6_sq6_sq5_no",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "sq_sq_sq_sq_min4_c16_l",
+    "outputKey": "sq6_sq6_sq5_no",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Sq_sq_sq_sq_c16_l",
+    "outputKey": "sq6_sq6_sq5_no",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Sq_sq_sq_sq_min4_c16_l",
+    "outputKey": "sq6_sq6_sq5_no",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Sq_Sq_sq_sq_c16_l",
+    "outputKey": "sq6_sq6_sq5_no",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Sq_Sq_sq_sq_min4_c16_l",
+    "outputKey": "sq6_sq6_sq5_no",
+  },
+  {
+    "damage": "327/320",
+    "inputKey": "Sq_Sq_Sq_sq_c16_l",
+    "outputKey": "Sq6_Sq5_Sq5_sq5",
+  },
+  {
+    "damage": "327/320",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c16_l",
+    "outputKey": "Sq6_Sq5_Sq5_sq5",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "Sq_Sq_Sq_Sq_c16_l",
+    "outputKey": "Sq6_Sq5_Sq5_Sq5",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c16_l",
+    "outputKey": "Sq6_Sq5_Sq5_Sq5",
+  },
+  {
+    "damage": "289/286",
+    "inputKey": "sq_sq_sq_sq_c15_l",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "289/286",
+    "inputKey": "sq_sq_sq_sq_min4_c15_l",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "289/286",
+    "inputKey": "Sq_sq_sq_sq_c15_l",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "289/286",
+    "inputKey": "Sq_sq_sq_sq_min4_c15_l",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "289/286",
+    "inputKey": "Sq_Sq_sq_sq_c15_l",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "289/286",
+    "inputKey": "Sq_Sq_sq_sq_min4_c15_l",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "289/286",
+    "inputKey": "Sq_Sq_Sq_sq_c15_l",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "289/286",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c15_l",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "289/286",
+    "inputKey": "Sq_Sq_Sq_Sq_c15_l",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "289/286",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c15_l",
+    "outputKey": "sq6_sq5_sq5_sq5",
+  },
+  {
+    "damage": "259/254",
+    "inputKey": "sq_sq_sq_sq_c14_l",
+    "outputKey": "sq6_sq5_sq5_sq3",
+  },
+  {
+    "damage": "275/254",
+    "inputKey": "sq_sq_sq_sq_min4_c14_l",
+    "outputKey": "sq6_sq5_sq5_sq4",
+  },
+  {
+    "damage": "259/254",
+    "inputKey": "Sq_sq_sq_sq_c14_l",
+    "outputKey": "sq6_sq5_sq5_sq3",
+  },
+  {
+    "damage": "275/254",
+    "inputKey": "Sq_sq_sq_sq_min4_c14_l",
+    "outputKey": "sq6_sq5_sq5_sq4",
+  },
+  {
+    "damage": "259/254",
+    "inputKey": "Sq_Sq_sq_sq_c14_l",
+    "outputKey": "sq6_sq5_sq5_sq3",
+  },
+  {
+    "damage": "275/254",
+    "inputKey": "Sq_Sq_sq_sq_min4_c14_l",
+    "outputKey": "sq6_sq5_sq5_sq4",
+  },
+  {
+    "damage": "259/254",
+    "inputKey": "Sq_Sq_Sq_sq_c14_l",
+    "outputKey": "sq6_sq5_sq5_sq3",
+  },
+  {
+    "damage": "275/254",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c14_l",
+    "outputKey": "sq6_sq5_sq5_sq4",
+  },
+  {
+    "damage": "259/254",
+    "inputKey": "Sq_Sq_Sq_Sq_c14_l",
+    "outputKey": "sq6_sq5_sq5_sq3",
+  },
+  {
+    "damage": "275/254",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c14_l",
+    "outputKey": "sq6_sq5_sq5_sq4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "sq_sq_sq_sq_c13_l",
+    "outputKey": "sq6_sq5_sq4_no",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "sq_sq_sq_sq_min4_c13_l",
+    "outputKey": "sq6_sq5_sq4_no",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Sq_sq_sq_sq_c13_l",
+    "outputKey": "sq6_sq5_sq4_no",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Sq_sq_sq_sq_min4_c13_l",
+    "outputKey": "sq6_sq5_sq4_no",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Sq_Sq_sq_sq_c13_l",
+    "outputKey": "sq6_sq5_sq4_no",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Sq_Sq_sq_sq_min4_c13_l",
+    "outputKey": "sq6_sq5_sq4_no",
+  },
+  {
+    "damage": "230/224",
+    "inputKey": "Sq_Sq_Sq_sq_c13_l",
+    "outputKey": "Sq5_Sq5_Sq5_sq5",
+  },
+  {
+    "damage": "230/224",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c13_l",
+    "outputKey": "Sq5_Sq5_Sq5_sq5",
+  },
+  {
+    "damage": "230/224",
+    "inputKey": "Sq_Sq_Sq_Sq_c13_l",
+    "outputKey": "Sq5_Sq5_Sq5_sq5",
+  },
+  {
+    "damage": "230/224",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c13_l",
+    "outputKey": "Sq5_Sq5_Sq5_sq5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "sq_sq_sq_sq_c12_l",
+    "outputKey": "sq5_sq5_sq5_sq5",
+  },
+  {
+    "damage": "204/196",
+    "inputKey": "sq_sq_sq_sq_min4_c12_l",
+    "outputKey": "sq5_sq5_sq5_sq5",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Sq_sq_sq_sq_c12_l",
+    "outputKey": "sq5_sq5_sq5_Sq4",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Sq_sq_sq_sq_min4_c12_l",
+    "outputKey": "sq5_sq5_sq5_Sq4",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Sq_Sq_sq_sq_c12_l",
+    "outputKey": "sq5_sq5_sq5_Sq4",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Sq_Sq_sq_sq_min4_c12_l",
+    "outputKey": "sq5_sq5_sq5_Sq4",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Sq_Sq_Sq_sq_c12_l",
+    "outputKey": "Sq5_sq5_Sq4_Sq4",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c12_l",
+    "outputKey": "Sq5_sq5_Sq4_Sq4",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Sq_Sq_Sq_Sq_c12_l",
+    "outputKey": "Sq5_sq5_Sq4_Sq4",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c12_l",
+    "outputKey": "Sq5_sq5_Sq4_Sq4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "sq_sq_sq_sq_c11_l",
+    "outputKey": "sq5_sq4_sq4_sq4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "sq_sq_sq_sq_min4_c11_l",
+    "outputKey": "sq5_sq4_sq4_sq4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "Sq_sq_sq_sq_c11_l",
+    "outputKey": "sq5_sq4_sq4_sq4",
+  },
+  {
+    "damage": "159/156",
+    "inputKey": "Sq_sq_sq_sq_min4_c11_l",
+    "outputKey": "sq5_sq4_sq4_sq4",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "Sq_Sq_sq_sq_c11_l",
+    "outputKey": "Sq4_Sq4_sq4_sq4",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "Sq_Sq_sq_sq_min4_c11_l",
+    "outputKey": "Sq4_Sq4_sq4_sq4",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "Sq_Sq_Sq_sq_c11_l",
+    "outputKey": "Sq4_Sq4_sq4_sq4",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c11_l",
+    "outputKey": "Sq4_Sq4_sq4_sq4",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "Sq_Sq_Sq_Sq_c11_l",
+    "outputKey": "Sq4_Sq4_sq4_sq4",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c11_l",
+    "outputKey": "Sq4_Sq4_sq4_sq4",
+  },
+  {
+    "damage": "143/132",
+    "inputKey": "sq_sq_sq_sq_c10_l",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "143/132",
+    "inputKey": "sq_sq_sq_sq_min4_c10_l",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_sq_sq_sq_c10_l",
+    "outputKey": "sq4_sq4_sq4_Sq3",
+  },
+  {
+    "damage": "143/132",
+    "inputKey": "Sq_sq_sq_sq_min4_c10_l",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_sq_sq_c10_l",
+    "outputKey": "sq4_sq4_sq4_Sq3",
+  },
+  {
+    "damage": "143/132",
+    "inputKey": "Sq_Sq_sq_sq_min4_c10_l",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_Sq_sq_c10_l",
+    "outputKey": "sq4_sq4_sq4_Sq3",
+  },
+  {
+    "damage": "143/132",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c10_l",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "133/132",
+    "inputKey": "Sq_Sq_Sq_Sq_c10_l",
+    "outputKey": "Sq4_Sq4_Sq3_Sq3",
+  },
+  {
+    "damage": "143/132",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c10_l",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "113/110",
+    "inputKey": "sq_sq_sq_sq_c9_l",
+    "outputKey": "sq4_sq4_sq3_sq3",
+  },
+  {
+    "damage": "143/110",
+    "inputKey": "sq_sq_sq_sq_min4_c9_l",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "113/110",
+    "inputKey": "Sq_sq_sq_sq_c9_l",
+    "outputKey": "sq4_sq4_sq3_sq3",
+  },
+  {
+    "damage": "143/110",
+    "inputKey": "Sq_sq_sq_sq_min4_c9_l",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "113/110",
+    "inputKey": "Sq_Sq_sq_sq_c9_l",
+    "outputKey": "sq4_sq4_sq3_sq3",
+  },
+  {
+    "damage": "143/110",
+    "inputKey": "Sq_Sq_sq_sq_min4_c9_l",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Sq_Sq_Sq_sq_c9_l",
+    "outputKey": "Sq4_Sq3_Sq3_sq3",
+  },
+  {
+    "damage": "143/110",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c9_l",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "Sq_Sq_Sq_Sq_c9_l",
+    "outputKey": "Sq4_Sq3_Sq3_Sq3",
+  },
+  {
+    "damage": "143/110",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c9_l",
+    "outputKey": "sq4_sq4_sq4_sq4",
+  },
+  {
+    "damage": "91/90",
+    "inputKey": "sq_sq_sq_sq_c8_l",
+    "outputKey": "sq4_sq3_sq3_sq2",
+  },
+  {
+    "damage": "108/90",
+    "inputKey": "sq_sq_sq_sq_min4_c8_l",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "91/90",
+    "inputKey": "Sq_sq_sq_sq_c8_l",
+    "outputKey": "sq4_sq3_sq3_sq2",
+  },
+  {
+    "damage": "108/90",
+    "inputKey": "Sq_sq_sq_sq_min4_c8_l",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "91/90",
+    "inputKey": "Sq_Sq_sq_sq_c8_l",
+    "outputKey": "sq4_sq3_sq3_sq2",
+  },
+  {
+    "damage": "108/90",
+    "inputKey": "Sq_Sq_sq_sq_min4_c8_l",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Sq_Sq_Sq_sq_c8_l",
+    "outputKey": "Sq3_Sq3_Sq3_sq3",
+  },
+  {
+    "damage": "108/90",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c8_l",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Sq_Sq_Sq_Sq_c8_l",
+    "outputKey": "Sq3_Sq3_Sq3_sq3",
+  },
+  {
+    "damage": "108/90",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c8_l",
+    "outputKey": "sq4_sq4_sq4_no",
+  },
+  {
+    "damage": "75/72",
+    "inputKey": "sq_sq_sq_sq_c7_l",
+    "outputKey": "sq3_sq3_sq3_sq2",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "sq_sq_sq_sq_min4_c7_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_sq_sq_sq_c7_l",
+    "outputKey": "sq3_sq3_Sq2_sq2",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_sq_sq_sq_min4_c7_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_sq_sq_c7_l",
+    "outputKey": "sq3_sq3_Sq2_sq2",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_sq_sq_min4_c7_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_Sq_sq_c7_l",
+    "outputKey": "sq3_Sq2_Sq2_Sq2",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c7_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_Sq_Sq_c7_l",
+    "outputKey": "sq3_Sq2_Sq2_Sq2",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c7_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "62/56",
+    "inputKey": "sq_sq_sq_sq_c6_l",
+    "outputKey": "sq3_sq2_sq2_sq2",
+  },
+  {
+    "damage": "72/56",
+    "inputKey": "sq_sq_sq_sq_min4_c6_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "Sq_sq_sq_sq_c6_l",
+    "outputKey": "Sq2_sq2_sq2_sq2",
+  },
+  {
+    "damage": "72/56",
+    "inputKey": "Sq_sq_sq_sq_min4_c6_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "Sq_Sq_sq_sq_c6_l",
+    "outputKey": "Sq2_sq2_sq2_sq2",
+  },
+  {
+    "damage": "72/56",
+    "inputKey": "Sq_Sq_sq_sq_min4_c6_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Sq_Sq_Sq_sq_c6_l",
+    "outputKey": "Sq2_Sq2_sq2_Sq1",
+  },
+  {
+    "damage": "72/56",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c6_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Sq_Sq_Sq_Sq_c6_l",
+    "outputKey": "Sq2_Sq2_sq2_Sq1",
+  },
+  {
+    "damage": "72/56",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c6_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "48/42",
+    "inputKey": "sq_sq_sq_sq_c5_l",
+    "outputKey": "sq2_sq2_sq2_sq1",
+  },
+  {
+    "damage": "72/42",
+    "inputKey": "sq_sq_sq_sq_min4_c5_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "43/42",
+    "inputKey": "Sq_sq_sq_sq_c5_l",
+    "outputKey": "sq2_sq2_Sq1_sq1",
+  },
+  {
+    "damage": "72/42",
+    "inputKey": "Sq_sq_sq_sq_min4_c5_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "43/42",
+    "inputKey": "Sq_Sq_sq_sq_c5_l",
+    "outputKey": "sq2_sq2_Sq1_sq1",
+  },
+  {
+    "damage": "72/42",
+    "inputKey": "Sq_Sq_sq_sq_min4_c5_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "43/42",
+    "inputKey": "Sq_Sq_Sq_sq_c5_l",
+    "outputKey": "sq2_sq2_Sq1_sq1",
+  },
+  {
+    "damage": "72/42",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c5_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "43/42",
+    "inputKey": "Sq_Sq_Sq_Sq_c5_l",
+    "outputKey": "Sq2_Sq1_Sq1_Sq1",
+  },
+  {
+    "damage": "72/42",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c5_l",
+    "outputKey": "sq4_sq4_no_no",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "sq_sq_sq_sq_c4_l",
+    "outputKey": "sq2_sq1_sq1_sq1",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "sq_sq_sq_sq_min4_c4_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_sq_sq_sq_c4_l",
+    "outputKey": "Sq1_sq1_sq1_sq1",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_sq_sq_sq_min4_c4_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_Sq_sq_sq_c4_l",
+    "outputKey": "Sq1_sq1_sq1_sq1",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_Sq_sq_sq_min4_c4_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_Sq_Sq_sq_c4_l",
+    "outputKey": "Sq1_sq1_sq1_sq1",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c4_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_Sq_Sq_Sq_c4_l",
+    "outputKey": "Sq1_sq1_sq1_sq1",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c4_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "sq_sq_sq_sq_c3_l",
+    "outputKey": "sq1_sq1_sq1_no",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "sq_sq_sq_sq_min4_c3_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_sq_sq_sq_c3_l",
+    "outputKey": "sq1_sq1_sq1_no",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "Sq_sq_sq_sq_min4_c3_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_Sq_sq_sq_c3_l",
+    "outputKey": "sq1_sq1_sq1_no",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "Sq_Sq_sq_sq_min4_c3_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_Sq_Sq_sq_c3_l",
+    "outputKey": "sq1_sq1_sq1_no",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c3_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_Sq_Sq_Sq_c3_l",
+    "outputKey": "sq1_sq1_sq1_no",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c3_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "sq_sq_sq_sq_c2_l",
+    "outputKey": "sq1_sq1_no_no",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "sq_sq_sq_sq_min4_c2_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "Sq_sq_sq_sq_c2_l",
+    "outputKey": "sq1_sq1_no_no",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "Sq_sq_sq_sq_min4_c2_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "Sq_Sq_sq_sq_c2_l",
+    "outputKey": "sq1_sq1_no_no",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "Sq_Sq_sq_sq_min4_c2_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "Sq_Sq_Sq_sq_c2_l",
+    "outputKey": "sq1_sq1_no_no",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c2_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "Sq_Sq_Sq_Sq_c2_l",
+    "outputKey": "sq1_sq1_no_no",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c2_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "sq_sq_sq_sq_c1_l",
+    "outputKey": "sq1_no_no_no",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "sq_sq_sq_sq_min4_c1_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Sq_sq_sq_sq_c1_l",
+    "outputKey": "sq1_no_no_no",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "Sq_sq_sq_sq_min4_c1_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Sq_Sq_sq_sq_c1_l",
+    "outputKey": "sq1_no_no_no",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "Sq_Sq_sq_sq_min4_c1_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Sq_Sq_Sq_sq_c1_l",
+    "outputKey": "sq1_no_no_no",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "Sq_Sq_Sq_sq_min4_c1_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Sq_Sq_Sq_Sq_c1_l",
+    "outputKey": "sq1_no_no_no",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "Sq_Sq_Sq_Sq_min4_c1_l",
+    "outputKey": "sq4_no_no_no",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "sq_sq_sq_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "sq_sq_sq_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_sq_sq_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_sq_sq_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_Sq_sq_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_Sq_sq_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_Sq_Sq_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_Sq_Sq_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "sq_sq_sq_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "sq_sq_sq_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_sq_sq_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_sq_sq_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_Sq_sq_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_Sq_sq_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "436/434",
+    "inputKey": "Sq_Sq_Sq_c19",
+    "outputKey": "Sq7_Sq7_Sq7",
+  },
+  {
+    "damage": "436/434",
+    "inputKey": "Sq_Sq_Sq_min4_c19",
+    "outputKey": "Sq7_Sq7_Sq7",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "sq_sq_sq_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "sq_sq_sq_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "Sq_sq_sq_c18",
+    "outputKey": "Sq7_sq7_sq7",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "Sq_sq_sq_min4_c18",
+    "outputKey": "Sq7_sq7_sq7",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "Sq_Sq_sq_c18",
+    "outputKey": "Sq7_sq7_sq7",
+  },
+  {
+    "damage": "398/394",
+    "inputKey": "Sq_Sq_sq_min4_c18",
+    "outputKey": "Sq7_sq7_sq7",
+  },
+  {
+    "damage": "401/394",
+    "inputKey": "Sq_Sq_Sq_c18",
+    "outputKey": "Sq7_Sq7_Sq6",
+  },
+  {
+    "damage": "401/394",
+    "inputKey": "Sq_Sq_Sq_min4_c18",
+    "outputKey": "Sq7_Sq7_Sq6",
+  },
+  {
+    "damage": "378/356",
+    "inputKey": "sq_sq_sq_c17",
+    "outputKey": "sq7_sq7_sq7",
+  },
+  {
+    "damage": "378/356",
+    "inputKey": "sq_sq_sq_min4_c17",
+    "outputKey": "sq7_sq7_sq7",
+  },
+  {
+    "damage": "363/356",
+    "inputKey": "Sq_sq_sq_c17",
+    "outputKey": "sq7_sq7_Sq6",
+  },
+  {
+    "damage": "363/356",
+    "inputKey": "Sq_sq_sq_min4_c17",
+    "outputKey": "sq7_sq7_Sq6",
+  },
+  {
+    "damage": "363/356",
+    "inputKey": "Sq_Sq_sq_c17",
+    "outputKey": "sq7_sq7_Sq6",
+  },
+  {
+    "damage": "363/356",
+    "inputKey": "Sq_Sq_sq_min4_c17",
+    "outputKey": "sq7_sq7_Sq6",
+  },
+  {
+    "damage": "366/356",
+    "inputKey": "Sq_Sq_Sq_c17",
+    "outputKey": "Sq7_Sq6_Sq6",
+  },
+  {
+    "damage": "366/356",
+    "inputKey": "Sq_Sq_Sq_min4_c17",
+    "outputKey": "Sq7_Sq6_Sq6",
+  },
+  {
+    "damage": "348/320",
+    "inputKey": "sq_sq_sq_c16",
+    "outputKey": "sq7_sq7_sq6",
+  },
+  {
+    "damage": "348/320",
+    "inputKey": "sq_sq_sq_min4_c16",
+    "outputKey": "sq7_sq7_sq6",
+  },
+  {
+    "damage": "333/320",
+    "inputKey": "Sq_sq_sq_c16",
+    "outputKey": "sq7_Sq6_sq6",
+  },
+  {
+    "damage": "333/320",
+    "inputKey": "Sq_sq_sq_min4_c16",
+    "outputKey": "sq7_Sq6_sq6",
+  },
+  {
+    "damage": "333/320",
+    "inputKey": "Sq_Sq_sq_c16",
+    "outputKey": "sq7_Sq6_sq6",
+  },
+  {
+    "damage": "333/320",
+    "inputKey": "Sq_Sq_sq_min4_c16",
+    "outputKey": "sq7_Sq6_sq6",
+  },
+  {
+    "damage": "332/320",
+    "inputKey": "Sq_Sq_Sq_c16",
+    "outputKey": "Sq6_Sq6_Sq6",
+  },
+  {
+    "damage": "332/320",
+    "inputKey": "Sq_Sq_Sq_min4_c16",
+    "outputKey": "Sq6_Sq6_Sq6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "sq_sq_sq_c15",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "sq_sq_sq_min4_c15",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Sq_sq_sq_c15",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Sq_sq_sq_min4_c15",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Sq_Sq_sq_c15",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Sq_Sq_sq_min4_c15",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Sq_Sq_Sq_c15",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "288/286",
+    "inputKey": "Sq_Sq_Sq_min4_c15",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "288/254",
+    "inputKey": "sq_sq_sq_c14",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "288/254",
+    "inputKey": "sq_sq_sq_min4_c14",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "288/254",
+    "inputKey": "Sq_sq_sq_c14",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "288/254",
+    "inputKey": "Sq_sq_sq_min4_c14",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "257/254",
+    "inputKey": "Sq_Sq_sq_c14",
+    "outputKey": "Sq6_Sq6_sq5",
+  },
+  {
+    "damage": "257/254",
+    "inputKey": "Sq_Sq_sq_min4_c14",
+    "outputKey": "Sq6_Sq6_sq5",
+  },
+  {
+    "damage": "263/254",
+    "inputKey": "Sq_Sq_Sq_c14",
+    "outputKey": "Sq6_Sq6_Sq5",
+  },
+  {
+    "damage": "263/254",
+    "inputKey": "Sq_Sq_Sq_min4_c14",
+    "outputKey": "Sq6_Sq6_Sq5",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "sq_sq_sq_c13",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "sq_sq_sq_min4_c13",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Sq_sq_sq_c13",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Sq_sq_sq_min4_c13",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Sq_Sq_sq_c13",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Sq_Sq_sq_min4_c13",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Sq_Sq_Sq_c13",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "228/224",
+    "inputKey": "Sq_Sq_Sq_min4_c13",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "197/196",
+    "inputKey": "sq_sq_sq_c12",
+    "outputKey": "sq6_sq6_sq1",
+  },
+  {
+    "damage": "218/196",
+    "inputKey": "sq_sq_sq_min4_c12",
+    "outputKey": "sq6_sq6_sq4",
+  },
+  {
+    "damage": "197/196",
+    "inputKey": "Sq_sq_sq_c12",
+    "outputKey": "sq6_sq6_sq1",
+  },
+  {
+    "damage": "218/196",
+    "inputKey": "Sq_sq_sq_min4_c12",
+    "outputKey": "sq6_sq6_sq4",
+  },
+  {
+    "damage": "197/196",
+    "inputKey": "Sq_Sq_sq_c12",
+    "outputKey": "sq6_sq6_sq1",
+  },
+  {
+    "damage": "218/196",
+    "inputKey": "Sq_Sq_sq_min4_c12",
+    "outputKey": "sq6_sq6_sq4",
+  },
+  {
+    "damage": "197/196",
+    "inputKey": "Sq_Sq_Sq_c12",
+    "outputKey": "sq6_sq6_sq1",
+  },
+  {
+    "damage": "218/196",
+    "inputKey": "Sq_Sq_Sq_min4_c12",
+    "outputKey": "sq6_sq6_sq4",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "sq_sq_sq_c11",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "sq_sq_sq_min4_c11",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "Sq_sq_sq_c11",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "Sq_sq_sq_min4_c11",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "Sq_Sq_sq_c11",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "Sq_Sq_sq_min4_c11",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "Sq_Sq_Sq_c11",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "Sq_Sq_Sq_min4_c11",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "sq_sq_sq_c10",
+    "outputKey": "sq6_sq5_no",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "sq_sq_sq_min4_c10",
+    "outputKey": "sq6_sq5_no",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_sq_sq_c10",
+    "outputKey": "sq6_sq5_no",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_sq_sq_min4_c10",
+    "outputKey": "sq6_sq5_no",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_sq_c10",
+    "outputKey": "sq6_sq5_no",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_sq_min4_c10",
+    "outputKey": "sq6_sq5_no",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_Sq_c10",
+    "outputKey": "sq6_sq5_no",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_Sq_min4_c10",
+    "outputKey": "sq6_sq5_no",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "sq_sq_sq_c9",
+    "outputKey": "sq6_sq3_no",
+  },
+  {
+    "damage": "122/110",
+    "inputKey": "sq_sq_sq_min4_c9",
+    "outputKey": "sq6_sq4_no",
+  },
+  {
+    "damage": "114/110",
+    "inputKey": "Sq_sq_sq_c9",
+    "outputKey": "Sq5_sq5_sq5",
+  },
+  {
+    "damage": "114/110",
+    "inputKey": "Sq_sq_sq_min4_c9",
+    "outputKey": "Sq5_sq5_sq5",
+  },
+  {
+    "damage": "110/110",
+    "inputKey": "Sq_Sq_sq_c9",
+    "outputKey": "Sq5_Sq5_sq4",
+  },
+  {
+    "damage": "110/110",
+    "inputKey": "Sq_Sq_sq_min4_c9",
+    "outputKey": "Sq5_Sq5_sq4",
+  },
+  {
+    "damage": "114/110",
+    "inputKey": "Sq_Sq_Sq_c9",
+    "outputKey": "Sq5_Sq5_Sq4",
+  },
+  {
+    "damage": "114/110",
+    "inputKey": "Sq_Sq_Sq_min4_c9",
+    "outputKey": "Sq5_Sq5_Sq4",
+  },
+  {
+    "damage": "98/90",
+    "inputKey": "sq_sq_sq_c8",
+    "outputKey": "sq5_sq5_sq4",
+  },
+  {
+    "damage": "98/90",
+    "inputKey": "sq_sq_sq_min4_c8",
+    "outputKey": "sq5_sq5_sq4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Sq_sq_sq_c8",
+    "outputKey": "sq5_Sq4_sq4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Sq_sq_sq_min4_c8",
+    "outputKey": "sq5_Sq4_sq4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Sq_Sq_sq_c8",
+    "outputKey": "sq5_Sq4_sq4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Sq_Sq_sq_min4_c8",
+    "outputKey": "sq5_Sq4_sq4",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "Sq_Sq_Sq_c8",
+    "outputKey": "Sq4_Sq4_Sq4",
+  },
+  {
+    "damage": "90/90",
+    "inputKey": "Sq_Sq_Sq_min4_c8",
+    "outputKey": "Sq4_Sq4_Sq4",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "sq_sq_sq_c7",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "sq_sq_sq_min4_c7",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "Sq_sq_sq_c7",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "Sq_sq_sq_min4_c7",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_sq_c7",
+    "outputKey": "Sq4_sq4_Sq3",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "Sq_Sq_sq_min4_c7",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_Sq_c7",
+    "outputKey": "Sq4_sq4_Sq3",
+  },
+  {
+    "damage": "76/72",
+    "inputKey": "Sq_Sq_Sq_min4_c7",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "sq_sq_sq_c6",
+    "outputKey": "sq4_sq4_sq1",
+  },
+  {
+    "damage": "76/56",
+    "inputKey": "sq_sq_sq_min4_c6",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Sq_sq_sq_c6",
+    "outputKey": "sq4_Sq3_sq3",
+  },
+  {
+    "damage": "76/56",
+    "inputKey": "Sq_sq_sq_min4_c6",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Sq_Sq_sq_c6",
+    "outputKey": "sq4_Sq3_sq3",
+  },
+  {
+    "damage": "76/56",
+    "inputKey": "Sq_Sq_sq_min4_c6",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Sq_Sq_Sq_c6",
+    "outputKey": "sq4_Sq3_sq3",
+  },
+  {
+    "damage": "76/56",
+    "inputKey": "Sq_Sq_Sq_min4_c6",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "sq_sq_sq_c5",
+    "outputKey": "sq3_sq3_sq3",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "sq_sq_sq_min4_c5",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "Sq_sq_sq_c5",
+    "outputKey": "sq3_sq3_sq3",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "Sq_sq_sq_min4_c5",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "Sq_Sq_sq_c5",
+    "outputKey": "Sq3_sq3_Sq2",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "Sq_Sq_sq_min4_c5",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "44/42",
+    "inputKey": "Sq_Sq_Sq_c5",
+    "outputKey": "Sq3_sq3_Sq2",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "Sq_Sq_Sq_min4_c5",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "sq_sq_sq_c4",
+    "outputKey": "sq3_sq2_sq2",
+  },
+  {
+    "damage": "51/30",
+    "inputKey": "sq_sq_sq_min4_c4",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_sq_sq_c4",
+    "outputKey": "Sq2_sq2_sq2",
+  },
+  {
+    "damage": "51/30",
+    "inputKey": "Sq_sq_sq_min4_c4",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_Sq_sq_c4",
+    "outputKey": "Sq2_sq2_sq2",
+  },
+  {
+    "damage": "51/30",
+    "inputKey": "Sq_Sq_sq_min4_c4",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_Sq_Sq_c4",
+    "outputKey": "Sq2_Sq2_Sq1",
+  },
+  {
+    "damage": "51/30",
+    "inputKey": "Sq_Sq_Sq_min4_c4",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "sq_sq_sq_c3",
+    "outputKey": "sq2_sq1_sq1",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "sq_sq_sq_min4_c3",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "Sq_sq_sq_c3",
+    "outputKey": "sq2_sq1_sq1",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_sq_sq_min4_c3",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "Sq_Sq_sq_c3",
+    "outputKey": "sq2_sq1_sq1",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_Sq_sq_min4_c3",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "Sq_Sq_Sq_c3",
+    "outputKey": "sq2_sq1_sq1",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_Sq_Sq_min4_c3",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "sq_sq_sq_c2",
+    "outputKey": "sq1_sq1_sq1",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "sq_sq_sq_min4_c2",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "Sq_sq_sq_c2",
+    "outputKey": "sq1_sq1_sq1",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Sq_sq_sq_min4_c2",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "Sq_Sq_sq_c2",
+    "outputKey": "Sq1_Sq1_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Sq_Sq_sq_min4_c2",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "Sq_Sq_Sq_c2",
+    "outputKey": "Sq1_Sq1_no",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Sq_Sq_Sq_min4_c2",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "sq_sq_sq_c1",
+    "outputKey": "sq1_sq1_no",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "sq_sq_sq_min4_c1",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "Sq_sq_sq_c1",
+    "outputKey": "sq1_sq1_no",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "Sq_sq_sq_min4_c1",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "Sq_Sq_sq_c1",
+    "outputKey": "sq1_sq1_no",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "Sq_Sq_sq_min4_c1",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "Sq_Sq_Sq_c1",
+    "outputKey": "sq1_sq1_no",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "Sq_Sq_Sq_min4_c1",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "493/476",
+    "inputKey": "sq_sq_sq_c20_l",
+    "outputKey": "sq7_sq7_sq6",
+  },
+  {
+    "damage": "493/476",
+    "inputKey": "sq_sq_sq_min4_c20_l",
+    "outputKey": "sq7_sq7_sq6",
+  },
+  {
+    "damage": "479/476",
+    "inputKey": "Sq_sq_sq_c20_l",
+    "outputKey": "Sq7_sq6_sq6",
+  },
+  {
+    "damage": "479/476",
+    "inputKey": "Sq_sq_sq_min4_c20_l",
+    "outputKey": "Sq7_sq6_sq6",
+  },
+  {
+    "damage": "492/476",
+    "inputKey": "Sq_Sq_sq_c20_l",
+    "outputKey": "sq7_Sq6_Sq6",
+  },
+  {
+    "damage": "492/476",
+    "inputKey": "Sq_Sq_sq_min4_c20_l",
+    "outputKey": "sq7_Sq6_Sq6",
+  },
+  {
+    "damage": "492/476",
+    "inputKey": "Sq_Sq_Sq_c20_l",
+    "outputKey": "sq7_Sq6_Sq6",
+  },
+  {
+    "damage": "492/476",
+    "inputKey": "Sq_Sq_Sq_min4_c20_l",
+    "outputKey": "sq7_Sq6_Sq6",
+  },
+  {
+    "damage": "451/434",
+    "inputKey": "sq_sq_sq_c19_l",
+    "outputKey": "sq7_sq6_sq6",
+  },
+  {
+    "damage": "451/434",
+    "inputKey": "sq_sq_sq_min4_c19_l",
+    "outputKey": "sq7_sq6_sq6",
+  },
+  {
+    "damage": "451/434",
+    "inputKey": "Sq_sq_sq_c19_l",
+    "outputKey": "sq7_sq6_sq6",
+  },
+  {
+    "damage": "451/434",
+    "inputKey": "Sq_sq_sq_min4_c19_l",
+    "outputKey": "sq7_sq6_sq6",
+  },
+  {
+    "damage": "449/434",
+    "inputKey": "Sq_Sq_sq_c19_l",
+    "outputKey": "Sq6_Sq6_sq6",
+  },
+  {
+    "damage": "449/434",
+    "inputKey": "Sq_Sq_sq_min4_c19_l",
+    "outputKey": "Sq6_Sq6_sq6",
+  },
+  {
+    "damage": "449/434",
+    "inputKey": "Sq_Sq_Sq_c19_l",
+    "outputKey": "Sq6_Sq6_sq6",
+  },
+  {
+    "damage": "449/434",
+    "inputKey": "Sq_Sq_Sq_min4_c19_l",
+    "outputKey": "Sq6_Sq6_sq6",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "sq_sq_sq_c18_l",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "sq_sq_sq_min4_c18_l",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Sq_sq_sq_c18_l",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Sq_sq_sq_min4_c18_l",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Sq_Sq_sq_c18_l",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Sq_Sq_sq_min4_c18_l",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Sq_Sq_Sq_c18_l",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "408/394",
+    "inputKey": "Sq_Sq_Sq_min4_c18_l",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "408/356",
+    "inputKey": "sq_sq_sq_c17_l",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "408/356",
+    "inputKey": "sq_sq_sq_min4_c17_l",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "408/356",
+    "inputKey": "Sq_sq_sq_c17_l",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "408/356",
+    "inputKey": "Sq_sq_sq_min4_c17_l",
+    "outputKey": "sq6_sq6_sq6",
+  },
+  {
+    "damage": "364/356",
+    "inputKey": "Sq_Sq_sq_c17_l",
+    "outputKey": "Sq6_Sq6_sq5",
+  },
+  {
+    "damage": "364/356",
+    "inputKey": "Sq_Sq_sq_min4_c17_l",
+    "outputKey": "Sq6_Sq6_sq5",
+  },
+  {
+    "damage": "356/356",
+    "inputKey": "Sq_Sq_Sq_c17_l",
+    "outputKey": "Sq6_Sq6_Sq4",
+  },
+  {
+    "damage": "356/356",
+    "inputKey": "Sq_Sq_Sq_min4_c17_l",
+    "outputKey": "Sq6_Sq6_Sq4",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "sq_sq_sq_c16_l",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "sq_sq_sq_min4_c16_l",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Sq_sq_sq_c16_l",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Sq_sq_sq_min4_c16_l",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Sq_Sq_sq_c16_l",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Sq_Sq_sq_min4_c16_l",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Sq_Sq_Sq_c16_l",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "323/320",
+    "inputKey": "Sq_Sq_Sq_min4_c16_l",
+    "outputKey": "sq6_sq6_sq5",
+  },
+  {
+    "damage": "286/286",
+    "inputKey": "sq_sq_sq_c15_l",
+    "outputKey": "sq6_sq6_sq2",
+  },
+  {
+    "damage": "309/286",
+    "inputKey": "sq_sq_sq_min4_c15_l",
+    "outputKey": "sq6_sq6_sq4",
+  },
+  {
+    "damage": "286/286",
+    "inputKey": "Sq_sq_sq_c15_l",
+    "outputKey": "sq6_sq6_sq2",
+  },
+  {
+    "damage": "309/286",
+    "inputKey": "Sq_sq_sq_min4_c15_l",
+    "outputKey": "sq6_sq6_sq4",
+  },
+  {
+    "damage": "286/286",
+    "inputKey": "Sq_Sq_sq_c15_l",
+    "outputKey": "sq6_sq6_sq2",
+  },
+  {
+    "damage": "309/286",
+    "inputKey": "Sq_Sq_sq_min4_c15_l",
+    "outputKey": "sq6_sq6_sq4",
+  },
+  {
+    "damage": "286/286",
+    "inputKey": "Sq_Sq_Sq_c15_l",
+    "outputKey": "sq6_sq6_sq2",
+  },
+  {
+    "damage": "309/286",
+    "inputKey": "Sq_Sq_Sq_min4_c15_l",
+    "outputKey": "sq6_sq6_sq4",
+  },
+  {
+    "damage": "272/254",
+    "inputKey": "sq_sq_sq_c14_l",
+    "outputKey": "sq6_sq6_no",
+  },
+  {
+    "damage": "272/254",
+    "inputKey": "sq_sq_sq_min4_c14_l",
+    "outputKey": "sq6_sq6_no",
+  },
+  {
+    "damage": "259/254",
+    "inputKey": "Sq_sq_sq_c14_l",
+    "outputKey": "Sq6_sq5_sq5",
+  },
+  {
+    "damage": "259/254",
+    "inputKey": "Sq_sq_sq_min4_c14_l",
+    "outputKey": "Sq6_sq5_sq5",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Sq_Sq_sq_c14_l",
+    "outputKey": "sq6_Sq5_Sq5",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Sq_Sq_sq_min4_c14_l",
+    "outputKey": "sq6_Sq5_Sq5",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Sq_Sq_Sq_c14_l",
+    "outputKey": "sq6_Sq5_Sq5",
+  },
+  {
+    "damage": "255/254",
+    "inputKey": "Sq_Sq_Sq_min4_c14_l",
+    "outputKey": "sq6_Sq5_Sq5",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "sq_sq_sq_c13_l",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "sq_sq_sq_min4_c13_l",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Sq_sq_sq_c13_l",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Sq_sq_sq_min4_c13_l",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Sq_Sq_sq_c13_l",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Sq_Sq_sq_min4_c13_l",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Sq_Sq_Sq_c13_l",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "224/224",
+    "inputKey": "Sq_Sq_Sq_min4_c13_l",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "sq_sq_sq_c12_l",
+    "outputKey": "sq6_sq5_sq2",
+  },
+  {
+    "damage": "224/196",
+    "inputKey": "sq_sq_sq_min4_c12_l",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "Sq_sq_sq_c12_l",
+    "outputKey": "sq6_sq5_sq2",
+  },
+  {
+    "damage": "224/196",
+    "inputKey": "Sq_sq_sq_min4_c12_l",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "Sq_Sq_sq_c12_l",
+    "outputKey": "sq6_sq5_sq2",
+  },
+  {
+    "damage": "224/196",
+    "inputKey": "Sq_Sq_sq_min4_c12_l",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "201/196",
+    "inputKey": "Sq_Sq_Sq_c12_l",
+    "outputKey": "sq6_sq5_sq2",
+  },
+  {
+    "damage": "224/196",
+    "inputKey": "Sq_Sq_Sq_min4_c12_l",
+    "outputKey": "sq6_sq5_sq4",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "sq_sq_sq_c11_l",
+    "outputKey": "sq6_sq3_no",
+  },
+  {
+    "damage": "173/156",
+    "inputKey": "sq_sq_sq_min4_c11_l",
+    "outputKey": "sq6_sq4_no",
+  },
+  {
+    "damage": "162/156",
+    "inputKey": "Sq_sq_sq_c11_l",
+    "outputKey": "Sq5_sq5_sq5",
+  },
+  {
+    "damage": "162/156",
+    "inputKey": "Sq_sq_sq_min4_c11_l",
+    "outputKey": "Sq5_sq5_sq5",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "Sq_Sq_sq_c11_l",
+    "outputKey": "Sq5_Sq5_sq4",
+  },
+  {
+    "damage": "156/156",
+    "inputKey": "Sq_Sq_sq_min4_c11_l",
+    "outputKey": "Sq5_Sq5_sq4",
+  },
+  {
+    "damage": "162/156",
+    "inputKey": "Sq_Sq_Sq_c11_l",
+    "outputKey": "Sq5_Sq5_Sq4",
+  },
+  {
+    "damage": "162/156",
+    "inputKey": "Sq_Sq_Sq_min4_c11_l",
+    "outputKey": "Sq5_Sq5_Sq4",
+  },
+  {
+    "damage": "139/132",
+    "inputKey": "sq_sq_sq_c10_l",
+    "outputKey": "sq5_sq5_sq4",
+  },
+  {
+    "damage": "139/132",
+    "inputKey": "sq_sq_sq_min4_c10_l",
+    "outputKey": "sq5_sq5_sq4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_sq_sq_c10_l",
+    "outputKey": "Sq5_sq4_sq4",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_sq_sq_min4_c10_l",
+    "outputKey": "Sq5_sq4_sq4",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "Sq_Sq_sq_c10_l",
+    "outputKey": "sq5_Sq4_Sq4",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "Sq_Sq_sq_min4_c10_l",
+    "outputKey": "sq5_Sq4_Sq4",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "Sq_Sq_Sq_c10_l",
+    "outputKey": "sq5_Sq4_Sq4",
+  },
+  {
+    "damage": "136/132",
+    "inputKey": "Sq_Sq_Sq_min4_c10_l",
+    "outputKey": "sq5_Sq4_Sq4",
+  },
+  {
+    "damage": "123/110",
+    "inputKey": "sq_sq_sq_c9_l",
+    "outputKey": "sq5_sq4_sq4",
+  },
+  {
+    "damage": "123/110",
+    "inputKey": "sq_sq_sq_min4_c9_l",
+    "outputKey": "sq5_sq4_sq4",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "Sq_sq_sq_c9_l",
+    "outputKey": "Sq4_sq4_sq4",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "Sq_sq_sq_min4_c9_l",
+    "outputKey": "Sq4_sq4_sq4",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "Sq_Sq_sq_c9_l",
+    "outputKey": "Sq4_sq4_sq4",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "Sq_Sq_sq_min4_c9_l",
+    "outputKey": "Sq4_sq4_sq4",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "Sq_Sq_Sq_c9_l",
+    "outputKey": "Sq4_sq4_sq4",
+  },
+  {
+    "damage": "115/110",
+    "inputKey": "Sq_Sq_Sq_min4_c9_l",
+    "outputKey": "Sq4_sq4_sq4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "sq_sq_sq_c8_l",
+    "outputKey": "sq4_sq4_sq3",
+  },
+  {
+    "damage": "108/90",
+    "inputKey": "sq_sq_sq_min4_c8_l",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Sq_sq_sq_c8_l",
+    "outputKey": "sq4_sq4_sq3",
+  },
+  {
+    "damage": "108/90",
+    "inputKey": "Sq_sq_sq_min4_c8_l",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Sq_Sq_sq_c8_l",
+    "outputKey": "sq4_sq4_sq3",
+  },
+  {
+    "damage": "108/90",
+    "inputKey": "Sq_Sq_sq_min4_c8_l",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "91/90",
+    "inputKey": "Sq_Sq_Sq_c8_l",
+    "outputKey": "Sq4_Sq3_Sq3",
+  },
+  {
+    "damage": "108/90",
+    "inputKey": "Sq_Sq_Sq_min4_c8_l",
+    "outputKey": "sq4_sq4_sq4",
+  },
+  {
+    "damage": "77/72",
+    "inputKey": "sq_sq_sq_c7_l",
+    "outputKey": "sq4_sq3_sq3",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "sq_sq_sq_min4_c7_l",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "77/72",
+    "inputKey": "Sq_sq_sq_c7_l",
+    "outputKey": "sq4_sq3_sq3",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_sq_sq_min4_c7_l",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "77/72",
+    "inputKey": "Sq_Sq_sq_c7_l",
+    "outputKey": "sq4_sq3_sq3",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_sq_min4_c7_l",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_Sq_c7_l",
+    "outputKey": "Sq3_Sq3_Sq3",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_Sq_min4_c7_l",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "62/56",
+    "inputKey": "sq_sq_sq_c6_l",
+    "outputKey": "sq3_sq3_sq3",
+  },
+  {
+    "damage": "72/56",
+    "inputKey": "sq_sq_sq_min4_c6_l",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "Sq_sq_sq_c6_l",
+    "outputKey": "sq3_sq3_Sq2",
+  },
+  {
+    "damage": "72/56",
+    "inputKey": "Sq_sq_sq_min4_c6_l",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "Sq_Sq_sq_c6_l",
+    "outputKey": "sq3_sq3_Sq2",
+  },
+  {
+    "damage": "72/56",
+    "inputKey": "Sq_Sq_sq_min4_c6_l",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "58/56",
+    "inputKey": "Sq_Sq_Sq_c6_l",
+    "outputKey": "Sq3_Sq2_Sq2",
+  },
+  {
+    "damage": "72/56",
+    "inputKey": "Sq_Sq_Sq_min4_c6_l",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "48/42",
+    "inputKey": "sq_sq_sq_c5_l",
+    "outputKey": "sq3_sq2_sq2",
+  },
+  {
+    "damage": "72/42",
+    "inputKey": "sq_sq_sq_min4_c5_l",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "Sq_sq_sq_c5_l",
+    "outputKey": "Sq2_sq2_sq2",
+  },
+  {
+    "damage": "72/42",
+    "inputKey": "Sq_sq_sq_min4_c5_l",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "Sq_Sq_sq_c5_l",
+    "outputKey": "Sq2_sq2_sq2",
+  },
+  {
+    "damage": "72/42",
+    "inputKey": "Sq_Sq_sq_min4_c5_l",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "43/42",
+    "inputKey": "Sq_Sq_Sq_c5_l",
+    "outputKey": "Sq2_Sq2_Sq1",
+  },
+  {
+    "damage": "72/42",
+    "inputKey": "Sq_Sq_Sq_min4_c5_l",
+    "outputKey": "sq4_sq4_no",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "sq_sq_sq_c4_l",
+    "outputKey": "sq2_sq2_sq1",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "sq_sq_sq_min4_c4_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_sq_sq_c4_l",
+    "outputKey": "sq2_Sq1_sq1",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_sq_sq_min4_c4_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_Sq_sq_c4_l",
+    "outputKey": "sq2_Sq1_sq1",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_Sq_sq_min4_c4_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_Sq_Sq_c4_l",
+    "outputKey": "sq2_Sq1_sq1",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_Sq_Sq_min4_c4_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "sq_sq_sq_c3_l",
+    "outputKey": "sq1_sq1_sq1",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "sq_sq_sq_min4_c3_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_sq_sq_c3_l",
+    "outputKey": "sq1_sq1_sq1",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "Sq_sq_sq_min4_c3_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_Sq_sq_c3_l",
+    "outputKey": "sq1_sq1_sq1",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "Sq_Sq_sq_min4_c3_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_Sq_Sq_c3_l",
+    "outputKey": "sq1_sq1_sq1",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "Sq_Sq_Sq_min4_c3_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "sq_sq_sq_c2_l",
+    "outputKey": "sq1_sq1_no",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "sq_sq_sq_min4_c2_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "Sq_sq_sq_c2_l",
+    "outputKey": "sq1_sq1_no",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "Sq_sq_sq_min4_c2_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "Sq_Sq_sq_c2_l",
+    "outputKey": "sq1_sq1_no",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "Sq_Sq_sq_min4_c2_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "Sq_Sq_Sq_c2_l",
+    "outputKey": "sq1_sq1_no",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "Sq_Sq_Sq_min4_c2_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "sq_sq_sq_c1_l",
+    "outputKey": "sq1_no_no",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "sq_sq_sq_min4_c1_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Sq_sq_sq_c1_l",
+    "outputKey": "sq1_no_no",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "Sq_sq_sq_min4_c1_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Sq_Sq_sq_c1_l",
+    "outputKey": "sq1_no_no",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "Sq_Sq_sq_min4_c1_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Sq_Sq_Sq_c1_l",
+    "outputKey": "sq1_no_no",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "Sq_Sq_Sq_min4_c1_l",
+    "outputKey": "sq4_no_no",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "sq_sq_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "sq_sq_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_sq_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_sq_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_Sq_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_Sq_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "sq_sq_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "sq_sq_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_sq_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_sq_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_Sq_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_Sq_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "sq_sq_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "sq_sq_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Sq_sq_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Sq_sq_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Sq_Sq_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Sq_Sq_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "sq_sq_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "sq_sq_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Sq_sq_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Sq_sq_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Sq_Sq_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Sq_Sq_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "sq_sq_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "sq_sq_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Sq_sq_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Sq_sq_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Sq_Sq_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Sq_Sq_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "sq_sq_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "sq_sq_min4_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "Sq_sq_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "Sq_sq_min4_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "291/286",
+    "inputKey": "Sq_Sq_c15",
+    "outputKey": "Sq7_Sq7",
+  },
+  {
+    "damage": "291/286",
+    "inputKey": "Sq_Sq_min4_c15",
+    "outputKey": "Sq7_Sq7",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "sq_sq_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "sq_sq_min4_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "272/254",
+    "inputKey": "Sq_sq_c14",
+    "outputKey": "Sq7_sq7",
+  },
+  {
+    "damage": "272/254",
+    "inputKey": "Sq_sq_min4_c14",
+    "outputKey": "Sq7_sq7",
+  },
+  {
+    "damage": "256/254",
+    "inputKey": "Sq_Sq_c14",
+    "outputKey": "Sq7_Sq6",
+  },
+  {
+    "damage": "256/254",
+    "inputKey": "Sq_Sq_min4_c14",
+    "outputKey": "Sq7_Sq6",
+  },
+  {
+    "damage": "252/224",
+    "inputKey": "sq_sq_c13",
+    "outputKey": "sq7_sq7",
+  },
+  {
+    "damage": "252/224",
+    "inputKey": "sq_sq_min4_c13",
+    "outputKey": "sq7_sq7",
+  },
+  {
+    "damage": "237/224",
+    "inputKey": "Sq_sq_c13",
+    "outputKey": "sq7_Sq6",
+  },
+  {
+    "damage": "237/224",
+    "inputKey": "Sq_sq_min4_c13",
+    "outputKey": "sq7_Sq6",
+  },
+  {
+    "damage": "237/224",
+    "inputKey": "Sq_Sq_c13",
+    "outputKey": "sq7_Sq6",
+  },
+  {
+    "damage": "237/224",
+    "inputKey": "Sq_Sq_min4_c13",
+    "outputKey": "sq7_Sq6",
+  },
+  {
+    "damage": "222/196",
+    "inputKey": "sq_sq_c12",
+    "outputKey": "sq7_sq6",
+  },
+  {
+    "damage": "222/196",
+    "inputKey": "sq_sq_min4_c12",
+    "outputKey": "sq7_sq6",
+  },
+  {
+    "damage": "207/196",
+    "inputKey": "Sq_sq_c12",
+    "outputKey": "Sq6_sq6",
+  },
+  {
+    "damage": "207/196",
+    "inputKey": "Sq_sq_min4_c12",
+    "outputKey": "Sq6_sq6",
+  },
+  {
+    "damage": "207/196",
+    "inputKey": "Sq_Sq_c12",
+    "outputKey": "Sq6_sq6",
+  },
+  {
+    "damage": "207/196",
+    "inputKey": "Sq_Sq_min4_c12",
+    "outputKey": "Sq6_sq6",
+  },
+  {
+    "damage": "192/156",
+    "inputKey": "sq_sq_c11",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "192/156",
+    "inputKey": "sq_sq_min4_c11",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "192/156",
+    "inputKey": "Sq_sq_c11",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "192/156",
+    "inputKey": "Sq_sq_min4_c11",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "192/156",
+    "inputKey": "Sq_Sq_c11",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "192/156",
+    "inputKey": "Sq_Sq_min4_c11",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "sq_sq_c10",
+    "outputKey": "sq6_sq5",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "sq_sq_min4_c10",
+    "outputKey": "sq6_sq5",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_sq_c10",
+    "outputKey": "sq6_sq5",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_sq_min4_c10",
+    "outputKey": "sq6_sq5",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_c10",
+    "outputKey": "sq6_sq5",
+  },
+  {
+    "damage": "132/132",
+    "inputKey": "Sq_Sq_min4_c10",
+    "outputKey": "sq6_sq5",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "sq_sq_c9",
+    "outputKey": "sq6_sq3",
+  },
+  {
+    "damage": "122/110",
+    "inputKey": "sq_sq_min4_c9",
+    "outputKey": "sq6_sq4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Sq_sq_c9",
+    "outputKey": "sq6_sq3",
+  },
+  {
+    "damage": "122/110",
+    "inputKey": "Sq_sq_min4_c9",
+    "outputKey": "sq6_sq4",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Sq_Sq_c9",
+    "outputKey": "sq6_sq3",
+  },
+  {
+    "damage": "122/110",
+    "inputKey": "Sq_Sq_min4_c9",
+    "outputKey": "sq6_sq4",
+  },
+  {
+    "damage": "101/90",
+    "inputKey": "sq_sq_c8",
+    "outputKey": "sq6_sq1",
+  },
+  {
+    "damage": "122/90",
+    "inputKey": "sq_sq_min4_c8",
+    "outputKey": "sq6_sq4",
+  },
+  {
+    "damage": "101/90",
+    "inputKey": "Sq_sq_c8",
+    "outputKey": "sq6_sq1",
+  },
+  {
+    "damage": "122/90",
+    "inputKey": "Sq_sq_min4_c8",
+    "outputKey": "sq6_sq4",
+  },
+  {
+    "damage": "101/90",
+    "inputKey": "Sq_Sq_c8",
+    "outputKey": "sq6_sq1",
+  },
+  {
+    "damage": "122/90",
+    "inputKey": "Sq_Sq_min4_c8",
+    "outputKey": "sq6_sq4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "sq_sq_c7",
+    "outputKey": "sq5_sq5",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "sq_sq_min4_c7",
+    "outputKey": "sq5_sq5",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_sq_c7",
+    "outputKey": "sq5_sq5",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_sq_min4_c7",
+    "outputKey": "sq5_sq5",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_c7",
+    "outputKey": "Sq5_Sq4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_min4_c7",
+    "outputKey": "Sq5_Sq4",
+  },
+  {
+    "damage": "62/56",
+    "inputKey": "sq_sq_c6",
+    "outputKey": "sq5_sq4",
+  },
+  {
+    "damage": "62/56",
+    "inputKey": "sq_sq_min4_c6",
+    "outputKey": "sq5_sq4",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "Sq_sq_c6",
+    "outputKey": "Sq4_sq4",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "Sq_sq_min4_c6",
+    "outputKey": "Sq4_sq4",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "Sq_Sq_c6",
+    "outputKey": "Sq4_sq4",
+  },
+  {
+    "damage": "56/56",
+    "inputKey": "Sq_Sq_min4_c6",
+    "outputKey": "Sq4_sq4",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "sq_sq_c5",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "sq_sq_min4_c5",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "42/42",
+    "inputKey": "Sq_sq_c5",
+    "outputKey": "sq4_Sq3",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "Sq_sq_min4_c5",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "42/42",
+    "inputKey": "Sq_Sq_c5",
+    "outputKey": "sq4_Sq3",
+  },
+  {
+    "damage": "51/42",
+    "inputKey": "Sq_Sq_min4_c5",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "sq_sq_c4",
+    "outputKey": "sq4_sq1",
+  },
+  {
+    "damage": "51/30",
+    "inputKey": "sq_sq_min4_c4",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_sq_c4",
+    "outputKey": "Sq3_sq3",
+  },
+  {
+    "damage": "51/30",
+    "inputKey": "Sq_sq_min4_c4",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_Sq_c4",
+    "outputKey": "Sq3_sq3",
+  },
+  {
+    "damage": "51/30",
+    "inputKey": "Sq_Sq_min4_c4",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "sq_sq_c3",
+    "outputKey": "sq2_sq2",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "sq_sq_min4_c3",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "Sq_sq_c3",
+    "outputKey": "sq2_sq2",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_sq_min4_c3",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "20/20",
+    "inputKey": "Sq_Sq_c3",
+    "outputKey": "sq2_sq2",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_Sq_min4_c3",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "sq_sq_c2",
+    "outputKey": "sq2_sq1",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "sq_sq_min4_c2",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "15/12",
+    "inputKey": "Sq_sq_c2",
+    "outputKey": "sq2_sq1",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Sq_sq_min4_c2",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "Sq_Sq_c2",
+    "outputKey": "Sq1_Sq1",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Sq_Sq_min4_c2",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "sq_sq_c1",
+    "outputKey": "sq1_sq1",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "sq_sq_min4_c1",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "Sq_sq_c1",
+    "outputKey": "sq1_sq1",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "Sq_sq_min4_c1",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "10/6",
+    "inputKey": "Sq_Sq_c1",
+    "outputKey": "sq1_sq1",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "Sq_Sq_min4_c1",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "sq_sq_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "sq_sq_min4_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_sq_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_sq_min4_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_Sq_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_Sq_min4_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "sq_sq_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "sq_sq_min4_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_sq_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_sq_min4_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_Sq_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_Sq_min4_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "sq_sq_c18_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "sq_sq_min4_c18_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Sq_sq_c18_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Sq_sq_min4_c18_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "412/394",
+    "inputKey": "Sq_Sq_c18_l",
+    "outputKey": "Sq7_Sq7",
+  },
+  {
+    "damage": "412/394",
+    "inputKey": "Sq_Sq_min4_c18_l",
+    "outputKey": "Sq7_Sq7",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "sq_sq_c17_l",
+    "outputKey": "sq7_sq7",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "sq_sq_min4_c17_l",
+    "outputKey": "sq7_sq7",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "Sq_sq_c17_l",
+    "outputKey": "sq7_sq7",
+  },
+  {
+    "damage": "357/356",
+    "inputKey": "Sq_sq_min4_c17_l",
+    "outputKey": "sq7_sq7",
+  },
+  {
+    "damage": "363/356",
+    "inputKey": "Sq_Sq_c17_l",
+    "outputKey": "Sq7_Sq6",
+  },
+  {
+    "damage": "363/356",
+    "inputKey": "Sq_Sq_min4_c17_l",
+    "outputKey": "Sq7_Sq6",
+  },
+  {
+    "damage": "357/320",
+    "inputKey": "sq_sq_c16_l",
+    "outputKey": "sq7_sq7",
+  },
+  {
+    "damage": "357/320",
+    "inputKey": "sq_sq_min4_c16_l",
+    "outputKey": "sq7_sq7",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "Sq_sq_c16_l",
+    "outputKey": "sq7_Sq6",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "Sq_sq_min4_c16_l",
+    "outputKey": "sq7_Sq6",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "Sq_Sq_c16_l",
+    "outputKey": "sq7_Sq6",
+  },
+  {
+    "damage": "336/320",
+    "inputKey": "Sq_Sq_min4_c16_l",
+    "outputKey": "sq7_Sq6",
+  },
+  {
+    "damage": "315/286",
+    "inputKey": "sq_sq_c15_l",
+    "outputKey": "sq7_sq6",
+  },
+  {
+    "damage": "315/286",
+    "inputKey": "sq_sq_min4_c15_l",
+    "outputKey": "sq7_sq6",
+  },
+  {
+    "damage": "293/286",
+    "inputKey": "Sq_sq_c15_l",
+    "outputKey": "Sq6_sq6",
+  },
+  {
+    "damage": "293/286",
+    "inputKey": "Sq_sq_min4_c15_l",
+    "outputKey": "Sq6_sq6",
+  },
+  {
+    "damage": "293/286",
+    "inputKey": "Sq_Sq_c15_l",
+    "outputKey": "Sq6_sq6",
+  },
+  {
+    "damage": "293/286",
+    "inputKey": "Sq_Sq_min4_c15_l",
+    "outputKey": "Sq6_sq6",
+  },
+  {
+    "damage": "272/254",
+    "inputKey": "sq_sq_c14_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "272/254",
+    "inputKey": "sq_sq_min4_c14_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "272/254",
+    "inputKey": "Sq_sq_c14_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "272/254",
+    "inputKey": "Sq_sq_min4_c14_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "272/254",
+    "inputKey": "Sq_Sq_c14_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "272/254",
+    "inputKey": "Sq_Sq_min4_c14_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "272/224",
+    "inputKey": "sq_sq_c13_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "272/224",
+    "inputKey": "sq_sq_min4_c13_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "272/224",
+    "inputKey": "Sq_sq_c13_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "272/224",
+    "inputKey": "Sq_sq_min4_c13_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "272/224",
+    "inputKey": "Sq_Sq_c13_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "272/224",
+    "inputKey": "Sq_Sq_min4_c13_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "272/196",
+    "inputKey": "sq_sq_c12_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "272/196",
+    "inputKey": "sq_sq_min4_c12_l",
+    "outputKey": "sq6_sq6",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Sq_sq_c12_l",
+    "outputKey": "sq6_Sq5",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Sq_sq_min4_c12_l",
+    "outputKey": "sq6_Sq5",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Sq_Sq_c12_l",
+    "outputKey": "sq6_Sq5",
+  },
+  {
+    "damage": "196/196",
+    "inputKey": "Sq_Sq_min4_c12_l",
+    "outputKey": "sq6_Sq5",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "sq_sq_c11_l",
+    "outputKey": "sq6_sq3",
+  },
+  {
+    "damage": "173/156",
+    "inputKey": "sq_sq_min4_c11_l",
+    "outputKey": "sq6_sq4",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "Sq_sq_c11_l",
+    "outputKey": "sq6_sq3",
+  },
+  {
+    "damage": "173/156",
+    "inputKey": "Sq_sq_min4_c11_l",
+    "outputKey": "sq6_sq4",
+  },
+  {
+    "damage": "157/156",
+    "inputKey": "Sq_Sq_c11_l",
+    "outputKey": "sq6_sq3",
+  },
+  {
+    "damage": "173/156",
+    "inputKey": "Sq_Sq_min4_c11_l",
+    "outputKey": "sq6_sq4",
+  },
+  {
+    "damage": "143/132",
+    "inputKey": "sq_sq_c10_l",
+    "outputKey": "sq6_sq1",
+  },
+  {
+    "damage": "173/132",
+    "inputKey": "sq_sq_min4_c10_l",
+    "outputKey": "sq6_sq4",
+  },
+  {
+    "damage": "143/132",
+    "inputKey": "Sq_sq_c10_l",
+    "outputKey": "sq6_sq1",
+  },
+  {
+    "damage": "173/132",
+    "inputKey": "Sq_sq_min4_c10_l",
+    "outputKey": "sq6_sq4",
+  },
+  {
+    "damage": "143/132",
+    "inputKey": "Sq_Sq_c10_l",
+    "outputKey": "sq6_sq1",
+  },
+  {
+    "damage": "173/132",
+    "inputKey": "Sq_Sq_min4_c10_l",
+    "outputKey": "sq6_sq4",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "sq_sq_c9_l",
+    "outputKey": "sq6_no",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "sq_sq_min4_c9_l",
+    "outputKey": "sq6_no",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Sq_sq_c9_l",
+    "outputKey": "Sq5_sq5",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Sq_sq_min4_c9_l",
+    "outputKey": "Sq5_sq5",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Sq_Sq_c9_l",
+    "outputKey": "Sq5_sq5",
+  },
+  {
+    "damage": "111/110",
+    "inputKey": "Sq_Sq_min4_c9_l",
+    "outputKey": "Sq5_sq5",
+  },
+  {
+    "damage": "102/90",
+    "inputKey": "sq_sq_c8_l",
+    "outputKey": "sq5_sq5",
+  },
+  {
+    "damage": "102/90",
+    "inputKey": "sq_sq_min4_c8_l",
+    "outputKey": "sq5_sq5",
+  },
+  {
+    "damage": "94/90",
+    "inputKey": "Sq_sq_c8_l",
+    "outputKey": "sq5_Sq4",
+  },
+  {
+    "damage": "94/90",
+    "inputKey": "Sq_sq_min4_c8_l",
+    "outputKey": "sq5_Sq4",
+  },
+  {
+    "damage": "94/90",
+    "inputKey": "Sq_Sq_c8_l",
+    "outputKey": "sq5_Sq4",
+  },
+  {
+    "damage": "94/90",
+    "inputKey": "Sq_Sq_min4_c8_l",
+    "outputKey": "sq5_Sq4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "sq_sq_c7_l",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "sq_sq_min4_c7_l",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_sq_c7_l",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_sq_min4_c7_l",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_c7_l",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "72/72",
+    "inputKey": "Sq_Sq_min4_c7_l",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "sq_sq_c6_l",
+    "outputKey": "sq4_sq3",
+  },
+  {
+    "damage": "72/56",
+    "inputKey": "sq_sq_min4_c6_l",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Sq_sq_c6_l",
+    "outputKey": "sq4_sq3",
+  },
+  {
+    "damage": "72/56",
+    "inputKey": "Sq_sq_min4_c6_l",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "57/56",
+    "inputKey": "Sq_Sq_c6_l",
+    "outputKey": "sq4_sq3",
+  },
+  {
+    "damage": "72/56",
+    "inputKey": "Sq_Sq_min4_c6_l",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "43/42",
+    "inputKey": "sq_sq_c5_l",
+    "outputKey": "sq4_sq1",
+  },
+  {
+    "damage": "72/42",
+    "inputKey": "sq_sq_min4_c5_l",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "Sq_sq_c5_l",
+    "outputKey": "Sq3_sq3",
+  },
+  {
+    "damage": "72/42",
+    "inputKey": "Sq_sq_min4_c5_l",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "Sq_Sq_c5_l",
+    "outputKey": "Sq3_sq3",
+  },
+  {
+    "damage": "72/42",
+    "inputKey": "Sq_Sq_min4_c5_l",
+    "outputKey": "sq4_sq4",
+  },
+  {
+    "damage": "34/30",
+    "inputKey": "sq_sq_c4_l",
+    "outputKey": "sq3_sq2",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "sq_sq_min4_c4_l",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "31/30",
+    "inputKey": "Sq_sq_c4_l",
+    "outputKey": "Sq2_sq2",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_sq_min4_c4_l",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "31/30",
+    "inputKey": "Sq_Sq_c4_l",
+    "outputKey": "Sq2_sq2",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_Sq_min4_c4_l",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "sq_sq_c3_l",
+    "outputKey": "sq2_sq1",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "sq_sq_min4_c3_l",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_sq_c3_l",
+    "outputKey": "sq2_sq1",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "Sq_sq_min4_c3_l",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_Sq_c3_l",
+    "outputKey": "sq2_sq1",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "Sq_Sq_min4_c3_l",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "sq_sq_c2_l",
+    "outputKey": "sq1_sq1",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "sq_sq_min4_c2_l",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "Sq_sq_c2_l",
+    "outputKey": "sq1_sq1",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "Sq_sq_min4_c2_l",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "14/12",
+    "inputKey": "Sq_Sq_c2_l",
+    "outputKey": "sq1_sq1",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "Sq_Sq_min4_c2_l",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "sq_sq_c1_l",
+    "outputKey": "sq1_no",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "sq_sq_min4_c1_l",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Sq_sq_c1_l",
+    "outputKey": "sq1_no",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "Sq_sq_min4_c1_l",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Sq_Sq_c1_l",
+    "outputKey": "sq1_no",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "Sq_Sq_min4_c1_l",
+    "outputKey": "sq4_no",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "sq_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "sq_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_min4_c20",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "sq_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "sq_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_min4_c19",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "sq_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "sq_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Sq_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Sq_min4_c18",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "sq_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "sq_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Sq_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Sq_min4_c17",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "sq_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "sq_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Sq_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Sq_min4_c16",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "sq_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "sq_min4_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "Sq_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "Sq_min4_c15",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "sq_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "sq_min4_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "Sq_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "Sq_min4_c14",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "sq_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "sq_min4_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "Sq_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "Sq_min4_c13",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "sq_c12",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "sq_min4_c12",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "Sq_c12",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "Sq_min4_c12",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/156",
+    "inputKey": "sq_c11",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/156",
+    "inputKey": "sq_min4_c11",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/156",
+    "inputKey": "Sq_c11",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/156",
+    "inputKey": "Sq_min4_c11",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/132",
+    "inputKey": "sq_c10",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/132",
+    "inputKey": "sq_min4_c10",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/132",
+    "inputKey": "Sq_c10",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/132",
+    "inputKey": "Sq_min4_c10",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/110",
+    "inputKey": "sq_c9",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/110",
+    "inputKey": "sq_min4_c9",
+    "outputKey": "",
+  },
+  {
+    "damage": "121/110",
+    "inputKey": "Sq_c9",
+    "outputKey": "Sq7",
+  },
+  {
+    "damage": "121/110",
+    "inputKey": "Sq_min4_c9",
+    "outputKey": "Sq7",
+  },
+  {
+    "damage": "105/90",
+    "inputKey": "sq_c8",
+    "outputKey": "sq7",
+  },
+  {
+    "damage": "105/90",
+    "inputKey": "sq_min4_c8",
+    "outputKey": "sq7",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Sq_c8",
+    "outputKey": "Sq6",
+  },
+  {
+    "damage": "92/90",
+    "inputKey": "Sq_min4_c8",
+    "outputKey": "Sq6",
+  },
+  {
+    "damage": "80/72",
+    "inputKey": "sq_c7",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "80/72",
+    "inputKey": "sq_min4_c7",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "80/72",
+    "inputKey": "Sq_c7",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "80/72",
+    "inputKey": "Sq_min4_c7",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "80/56",
+    "inputKey": "sq_c6",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "80/56",
+    "inputKey": "sq_min4_c6",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "80/56",
+    "inputKey": "Sq_c6",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "80/56",
+    "inputKey": "Sq_min4_c6",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "80/42",
+    "inputKey": "sq_c5",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "80/42",
+    "inputKey": "sq_min4_c5",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "80/42",
+    "inputKey": "Sq_c5",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "80/42",
+    "inputKey": "Sq_min4_c5",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "sq_c4",
+    "outputKey": "sq5",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "sq_min4_c4",
+    "outputKey": "sq5",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_c4",
+    "outputKey": "sq5",
+  },
+  {
+    "damage": "30/30",
+    "inputKey": "Sq_min4_c4",
+    "outputKey": "sq5",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "sq_c3",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "sq_min4_c3",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_c3",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_min4_c3",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "sq_c2",
+    "outputKey": "sq3",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "sq_min4_c2",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "Sq_c2",
+    "outputKey": "sq3",
+  },
+  {
+    "damage": "21/12",
+    "inputKey": "Sq_min4_c2",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "8/6",
+    "inputKey": "sq_c1",
+    "outputKey": "sq2",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "sq_min4_c1",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "8/6",
+    "inputKey": "Sq_c1",
+    "outputKey": "sq2",
+  },
+  {
+    "damage": "21/6",
+    "inputKey": "Sq_min4_c1",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "sq_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "sq_min4_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/476",
+    "inputKey": "Sq_min4_c20_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "sq_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "sq_min4_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/434",
+    "inputKey": "Sq_min4_c19_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "sq_c18_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "sq_min4_c18_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Sq_c18_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/394",
+    "inputKey": "Sq_min4_c18_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "sq_c17_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "sq_min4_c17_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Sq_c17_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/356",
+    "inputKey": "Sq_min4_c17_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "sq_c16_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "sq_min4_c16_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Sq_c16_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/320",
+    "inputKey": "Sq_min4_c16_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "sq_c15_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "sq_min4_c15_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "Sq_c15_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/286",
+    "inputKey": "Sq_min4_c15_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "sq_c14_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "sq_min4_c14_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "Sq_c14_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/254",
+    "inputKey": "Sq_min4_c14_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "sq_c13_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "sq_min4_c13_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "Sq_c13_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/224",
+    "inputKey": "Sq_min4_c13_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "sq_c12_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "sq_min4_c12_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "Sq_c12_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "0/196",
+    "inputKey": "Sq_min4_c12_l",
+    "outputKey": "",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "sq_c11_l",
+    "outputKey": "sq7",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "sq_min4_c11_l",
+    "outputKey": "sq7",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "Sq_c11_l",
+    "outputKey": "sq7",
+  },
+  {
+    "damage": "158/156",
+    "inputKey": "Sq_min4_c11_l",
+    "outputKey": "sq7",
+  },
+  {
+    "damage": "158/132",
+    "inputKey": "sq_c10_l",
+    "outputKey": "sq7",
+  },
+  {
+    "damage": "158/132",
+    "inputKey": "sq_min4_c10_l",
+    "outputKey": "sq7",
+  },
+  {
+    "damage": "138/132",
+    "inputKey": "Sq_c10_l",
+    "outputKey": "Sq6",
+  },
+  {
+    "damage": "138/132",
+    "inputKey": "Sq_min4_c10_l",
+    "outputKey": "Sq6",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "sq_c9_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "sq_min4_c9_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "Sq_c9_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/110",
+    "inputKey": "Sq_min4_c9_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/90",
+    "inputKey": "sq_c8_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/90",
+    "inputKey": "sq_min4_c8_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/90",
+    "inputKey": "Sq_c8_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/90",
+    "inputKey": "Sq_min4_c8_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/72",
+    "inputKey": "sq_c7_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/72",
+    "inputKey": "sq_min4_c7_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/72",
+    "inputKey": "Sq_c7_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/72",
+    "inputKey": "Sq_min4_c7_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/56",
+    "inputKey": "sq_c6_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/56",
+    "inputKey": "sq_min4_c6_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/56",
+    "inputKey": "Sq_c6_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "120/56",
+    "inputKey": "Sq_min4_c6_l",
+    "outputKey": "sq6",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "sq_c5_l",
+    "outputKey": "sq5",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "sq_min4_c5_l",
+    "outputKey": "sq5",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "Sq_c5_l",
+    "outputKey": "sq5",
+  },
+  {
+    "damage": "45/42",
+    "inputKey": "Sq_min4_c5_l",
+    "outputKey": "sq5",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "sq_c4_l",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "sq_min4_c4_l",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_c4_l",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "32/30",
+    "inputKey": "Sq_min4_c4_l",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "sq_c3_l",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "sq_min4_c3_l",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "21/20",
+    "inputKey": "Sq_c3_l",
+    "outputKey": "Sq3",
+  },
+  {
+    "damage": "32/20",
+    "inputKey": "Sq_min4_c3_l",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "sq_c2_l",
+    "outputKey": "sq2",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "sq_min4_c2_l",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "12/12",
+    "inputKey": "Sq_c2_l",
+    "outputKey": "sq2",
+  },
+  {
+    "damage": "32/12",
+    "inputKey": "Sq_min4_c2_l",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "sq_c1_l",
+    "outputKey": "sq1",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "sq_min4_c1_l",
+    "outputKey": "sq4",
+  },
+  {
+    "damage": "6/6",
+    "inputKey": "Sq_c1_l",
+    "outputKey": "sq1",
+  },
+  {
+    "damage": "32/6",
+    "inputKey": "Sq_min4_c1_l",
+    "outputKey": "sq4",
   },
 ]
 `;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,9 +14,7 @@ export enum GagTracks {
 // String union version, so that string literal or GagTracks enum can be provided
 export type GagTrack = `${GagTracks}`;
 
-export const gagTracksArr: GagTracks[] = Object.values(GagTracks);
-
-export const gagTracksOrder: Record<GagTracks, number> = {
+export const GAG_TRACKS_ORDER: Record<GagTracks, number> = {
   [GagTracks.toonup]: 0,
   [GagTracks.trap]: 1,
   [GagTracks.lure]: 2,
@@ -27,7 +25,7 @@ export const gagTracksOrder: Record<GagTracks, number> = {
 };
 
 // TODO Can extend this to include other info such as accuracy
-export const gags: Record<GagTracks, Record<number, { name: string; damage: number; }>> = {
+export const GAGS: Record<GagTracks, Record<number, { name: string; damage: number; }>> = {
   [GagTracks.toonup]: {
     1: { name: 'Feather',         damage: 0 },
     2: { name: 'Megaphone',       damage: 0 },
@@ -93,7 +91,7 @@ export const gags: Record<GagTracks, Record<number, { name: string; damage: numb
   },
 };
 
-export const cogHp: Record<number, number> = {
+export const COG_HP: Record<number, number> = {
   1:  6,
   2:  12,
   3:  20,
@@ -118,7 +116,7 @@ export const cogHp: Record<number, number> = {
 
 export const BASE_URL: string = import.meta.env?.BASE_URL ?? '';
 
-export const gagTrackDisplayName: Record<GagTrack, string> = {
+export const GAG_TRACK_DISPLAY_NAME: Record<GagTrack, string> = {
   toonup: 'Toon-Up',
   trap:   'Trap',
   lure:   'Lure',
@@ -140,7 +138,7 @@ export enum SosToons {
   BarnacleBessie,
 };
 
-export const sosToonGags: Record<
+export const SOS_TOON_GAGS: Record<
   GagTracks.trap | GagTracks.sound | GagTracks.drop,
   Record<number, { name: string; damage: number; sosToon: SosToons; }>
 > = {
@@ -161,7 +159,7 @@ export const sosToonGags: Record<
   },
 };
 
-export const additionalGagMultipliers: Record<number, string> = {
+export const ADDITIONAL_GAG_MULTIPLIERS: Record<number, string> = {
   [0]:      'None',
   [-0.1]:   '-10% (1-star FO Market Research)',
   [-0.15]:  '-15% (2-star FO Market Research)',

--- a/src/gags-cli.ts
+++ b/src/gags-cli.ts
@@ -1,13 +1,13 @@
-import { findCombo, logTable } from './gags';
+import { findCombo, FindComboResult, logTable } from './gags';
 
 const args: Parameters<typeof findCombo>[0] = {
-  cogLvl: 11,
+  cogLvl: 12,
   isLured: false,
   gags: {
     toonup: 0,
     trap:   0,
     lure:   0,
-    sound:  3,
+    sound:  4,
     throw:  0,
     squirt: 0,
     drop:   0,
@@ -16,13 +16,15 @@ const args: Parameters<typeof findCombo>[0] = {
     toonup: 0,
     trap:   0,
     lure:   0,
-    sound:  2,
+    sound:  3,
     throw:  0,
     squirt: 0,
     drop:   0,
   },
+  minGagLvl: undefined,
+  additionalGagMultiplier: undefined,
 };
 
 const combo = findCombo(args);
-logTable(combo);
+logTable(new FindComboResult(args, combo));
 

--- a/src/gags.test.ts
+++ b/src/gags.test.ts
@@ -1,51 +1,92 @@
-import { findCombo, FindComboResult, Combo, Gag, Cog } from './gags';
+import {
+  findCombo,
+  FindComboResult,
+  FindComboArgs,
+  Combo,
+  Gag,
+  sortFnGags,
+  sortFnGagsLowest,
+  cleanGagCounts,
+  findComboArgsToKey,
+  keyToFindComboArgs,
+  FindComboArgsKey,
+  ComboKey,
+} from './gags';
 import { GagTracks } from './constants';
 import * as util from './util';
 
-type IterFindComboArgsArgs = Parameters<typeof util.iterFindComboArgs>[0];
+const GT = GagTracks;
 
 describe('findCombo', () => {
-  test.each<IterFindComboArgsArgs>([
-    { maxCogLvl: 12, organicGags: {}, isLured: false },
-  ])('combos match the snapshot for args %j', (args) => {
+  test('matches snapshot for all permutations relevant to combo grid', () => {
     const findComboResults: Array<FindComboResult> = Array.from(
-      util.iterFindComboArgs(args),
-      findComboArgs => findCombo(findComboArgs),
-    )
-    expect(findComboResults).toMatchSnapshot();
+      iterFindComboArgsComboGridPermutations(),
+      findComboArgs => new FindComboResult(findComboArgs, findCombo(findComboArgs)),
+    );
+    expectFindComboResults(findComboResults);
+  });
+
+  test('matches snapshot for all 2sound2drop & 3sound1drop permutations', () => {
+    const findComboResults: Array<FindComboResult> = Array.from(
+      iterFindComboArgsSoundDropPermutations(),
+      findComboArgs => new FindComboResult(findComboArgs, findCombo(findComboArgs)),
+    );
+    expectFindComboResults(findComboResults);
+  });
+
+  function expectFindComboResults(findComboResults: Array<FindComboResult>) {
+    for (const res of findComboResults) {
+      if (!res.combo) continue;
+      expect.soft(
+        res.combo.damageKillsCog(res.cog, res.args.additionalGagMultiplier),
+        `[${res.inputKey()}] Non-null combo does not kill cog`
+      ).toBe(true);
+      const orgTrackCounts = res.combo.orgTrackCounts();
+      for (const [track, orgsAvailable] of Object.entries(res.args.organicGags)) {
+        const orgsUsed = orgTrackCounts[track as GagTracks];
+        if (orgsUsed > orgsAvailable) { // Extra condition check for lazy expect message creation
+          expect.soft(
+            orgsUsed,
+            `[${res.inputKey()}] More orgs used in combo than available for track ${track} ` +
+            `(${orgsUsed} > ${orgsAvailable}) ${JSON.stringify(res.shortView())}\n`
+          ).toBeLessThanOrEqual(orgsAvailable);
+        }
+      }
+    }
+    expect(findComboResults.map(res => res.shortView())).toMatchSnapshot();
+  }
+});
+
+const findComboArgsToFromKeyTestCases: [FindComboArgs, string][] = [
+  [{ gags: { throw: 4 }, organicGags: { throw: 3 }, minGagLvl: 4, cogLvl: 14, isLured: true }, 'Th_Th_Th_th_min4_c14_l'],
+  [{ gags: { throw: 2, squirt: 1 }, organicGags: { throw: 1, squirt: 1 }, cogLvl: 1, isLured: false }, 'Th_th_Sq_c1'],
+  [{ gags: { drop: 1, throw: 2 }, organicGags: { throw: 1 }, minGagLvl: 5, cogLvl: 12, isLured: false }, 'Th_th_dr_min5_c12'],
+  [{ gags: { drop: 1 }, organicGags: {}, minGagLvl: 4, cogLvl: 9, isLured: true, additionalGagMultiplier: -0.25 }, 'dr_min4_c9_l_*-0.25'],
+  [{ gags: {}, organicGags: {}, minGagLvl: 4, cogLvl: 9, isLured: true, additionalGagMultiplier: 0.6 }, 'min4_c9_l_*0.6'],
+];
+
+describe('findComboArgsToKey', () => {
+  test.each(
+    findComboArgsToFromKeyTestCases
+  )('converts `FindComboArgs` object to string key', (findComboArgs, key) => {
+    expect(findComboArgsToKey(findComboArgs)).toEqual(key);
   });
 });
 
-describe('FindComboResult', () => {
-  describe('inputKey & outputKey', () => {
-    test.each([
-      new FindComboResult({
-        combo: new Combo({ gags: [] }),
-        cog: new Cog({ lvl: 11, isLured: true }),
-        gagsInput: { sound: 1, throw: 1, squirt: 2 },
-        organicGagsInput: {},
-      }),
-      new FindComboResult({
-        combo: new Combo({ gags: [] }),
-        cog: new Cog({ lvl: 11, isLured: false }),
-        gagsInput: { drop: 2, squirt: 2 },
-        organicGagsInput: { drop: 1 },
-      }),
-    ])('generates the expected input key and output key', (findComboRes) => {
-      expect({
-        inputKey: findComboRes.inputKey(),
-        outputKey: findComboRes.outputKey(),
-      }).toMatchSnapshot();
-    });
+describe('keyToFindComboArgs', () => {
+  test.each(
+    findComboArgsToFromKeyTestCases
+  )('converts string key to `FindComboArgs` object', (findComboArgs, key) => {
+    expect(keyToFindComboArgs(key as FindComboArgsKey)).toEqual(findComboArgs);
   });
+});
 
-  describe('cleanGagCounts', () => {
-    test('sorts keys to match gag track order and omits 0 or undefined values', () => {
-      const cleaned = Combo.cleanGagCounts({ drop: 0, squirt: 1, toonup: 3, lure: undefined });
-      expect(JSON.stringify(cleaned)).toEqual(
-        '{"toonup":3,"squirt":1}'
-      );
-    });
+describe('cleanGagCounts', () => {
+  test('sorts keys to match gag track order and omits 0 or undefined values', () => {
+    const cleaned = cleanGagCounts({ drop: 0, squirt: 1, toonup: 3, lure: undefined });
+    expect(JSON.stringify(cleaned)).toEqual(
+      '{"toonup":3,"squirt":1}'
+    );
   });
 });
 
@@ -122,5 +163,177 @@ describe('Combo', () => {
       expect(combo.damage({ additionalGagMultiplier })).toBe(expectedDamage);
     });
   });
+
+  const comboToFromKeyTestCases: [Combo, string][] = [
+    [
+      new Combo({ gags: [
+        new Gag({ track: GT.throw, lvl: 6, isOrg: true }),
+        new Gag({ track: GT.throw, lvl: 5, isOrg: true }),
+        new Gag({ track: GT.squirt, lvl: 7 }),
+      ] }),
+      'Th6_Th5_sq7'
+    ],
+  ];
+
+  describe('toKey', () => {
+    test.each(
+      comboToFromKeyTestCases
+    )('converts `Combo` object to string key', (combo, key) => {
+      expect(combo.toKey()).toEqual(key);
+    });
+  });
+
+  describe('fromKey', () => {
+    test.each(
+      comboToFromKeyTestCases
+    )('converts string key to `Combo` object', (combo, key) => {
+      expect(Combo.fromKey(key as ComboKey)).toEqual(combo);
+    });
+  });
 });
+
+describe('sortFnGags', () => {
+  test('sorts by track order, then by damage, high to low', () => {
+    expect([
+      new Gag({ track: GT.drop, lvl: 1, isOrg: false }),
+      new Gag({ track: GT.toonup, lvl: 1, isOrg: true }),
+      new Gag({ track: GT.drop, lvl: 1, isOrg: true }),
+      new Gag({ track: GT.squirt, lvl: 1, isOrg: false }),
+      new Gag({ track: GT.drop, lvl: 2, isOrg: false }),
+      new Gag({ track: GT.trap, lvl: 1, isOrg: false }),
+      new Gag({ track: GT.lure, lvl: 1, isOrg: true }),
+      new Gag({ track: GT.sound, lvl: 1, isOrg: true }),
+      new Gag({ track: GT.throw, lvl: 1, isOrg: false }),
+      new Gag({ track: GT.trap, lvl: 1, isOrg: true }),
+      new Gag({ track: GT.toonup, lvl: 1, isOrg: false }),
+      new Gag({ track: GT.throw, lvl: 1, isOrg: true }),
+      new Gag({ track: GT.sound, lvl: 1, isOrg: false }),
+      new Gag({ track: GT.lure, lvl: 1, isOrg: false }),
+      new Gag({ track: GT.squirt, lvl: 1, isOrg: true }),
+    ].toSorted(sortFnGags)).toEqual([
+      new Gag({ track: GT.toonup, lvl: 1, isOrg: true }),
+      new Gag({ track: GT.toonup, lvl: 1, isOrg: false }),
+      new Gag({ track: GT.trap, lvl: 1, isOrg: true }),
+      new Gag({ track: GT.trap, lvl: 1, isOrg: false }),
+      new Gag({ track: GT.lure, lvl: 1, isOrg: true }),
+      new Gag({ track: GT.lure, lvl: 1, isOrg: false }),
+      new Gag({ track: GT.sound, lvl: 1, isOrg: true }),
+      new Gag({ track: GT.sound, lvl: 1, isOrg: false }),
+      new Gag({ track: GT.throw, lvl: 1, isOrg: true }),
+      new Gag({ track: GT.throw, lvl: 1, isOrg: false }),
+      new Gag({ track: GT.squirt, lvl: 1, isOrg: true }),
+      new Gag({ track: GT.squirt, lvl: 1, isOrg: false }),
+      new Gag({ track: GT.drop, lvl: 2, isOrg: false }),
+      new Gag({ track: GT.drop, lvl: 1, isOrg: true }),
+      new Gag({ track: GT.drop, lvl: 1, isOrg: false }),
+    ]);
+  });
+});
+
+describe('sortFnGagsLowest', () => {
+  test('sorts by damage, low to high', () => {
+    const arr = [
+      new Gag({ track: GT.drop,    lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.toonup,  lvl: 1,  isOrg: true  }),
+      new Gag({ track: GT.drop,    lvl: 1,  isOrg: true  }),
+      new Gag({ track: GT.squirt,  lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.drop,    lvl: 2,  isOrg: false }),
+      new Gag({ track: GT.drop,    lvl: 0,  isOrg: true  }),
+      new Gag({ track: GT.drop,    lvl: 0,  isOrg: false }),
+      new Gag({ track: GT.trap,    lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.lure,    lvl: 1,  isOrg: true  }),
+      new Gag({ track: GT.sound,   lvl: 1,  isOrg: true  }),
+      new Gag({ track: GT.sound,   lvl: 0,  isOrg: true  }),
+      new Gag({ track: GT.sound,   lvl: 0,  isOrg: false }),
+      new Gag({ track: GT.throw,   lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.trap,    lvl: 1,  isOrg: true  }),
+      new Gag({ track: GT.toonup,  lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.throw,   lvl: 1,  isOrg: true  }),
+      new Gag({ track: GT.sound,   lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.lure,    lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.squirt,  lvl: 1,  isOrg: true  }),
+    ];
+
+    const sorted = arr.toSorted(sortFnGagsLowest);
+
+    expect(sorted).toEqual([
+      new Gag({ track: GT.sound,   lvl: 0,  isOrg: false }),
+      new Gag({ track: GT.sound,   lvl: 0,  isOrg: true  }),
+      new Gag({ track: GT.drop,    lvl: 0,  isOrg: false }),
+      new Gag({ track: GT.drop,    lvl: 0,  isOrg: true  }),
+      new Gag({ track: GT.toonup,  lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.toonup,  lvl: 1,  isOrg: true  }),
+      new Gag({ track: GT.lure,    lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.lure,    lvl: 1,  isOrg: true  }),
+
+      new Gag({ track: GT.sound,   lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.squirt,  lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.sound,   lvl: 1,  isOrg: true  }),
+      new Gag({ track: GT.squirt,  lvl: 1,  isOrg: true  }),
+      new Gag({ track: GT.throw,   lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.throw,   lvl: 1,  isOrg: true  }),
+      new Gag({ track: GT.drop,    lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.trap,    lvl: 1,  isOrg: false }),
+      new Gag({ track: GT.drop,    lvl: 1,  isOrg: true  }),
+      new Gag({ track: GT.trap,    lvl: 1,  isOrg: true  }),
+      new Gag({ track: GT.drop,    lvl: 2,  isOrg: false }),
+    ]);
+  });
+});
+
+function* iterFindComboArgsComboGridPermutations(): Generator<FindComboArgs> {
+  for (const { gagTrack, numToons } of (
+    [GagTracks.sound, GagTracks.throw, GagTracks.squirt]
+    .flatMap(gagTrack => Array.from(
+      util.range(4, 1, -1),
+      numToons => ({ gagTrack, numToons })
+    ))
+  )) {
+    const maxCogLvl = 20;
+    for (
+      const isLured of (
+        gagTrack === GagTracks.throw || gagTrack === GagTracks.squirt
+        ? [false, true]
+        : [false]
+      )
+    ) {
+      for (let cogLvl = maxCogLvl; cogLvl >= 1; cogLvl--) {
+        for (let numOrg = 0; numOrg <= numToons; numOrg++) {
+          for (const minGagLvl of [undefined, 4]) {
+            yield {
+              minGagLvl,
+              isLured,
+              cogLvl,
+              gags: { [gagTrack]: numToons },
+              organicGags: { [gagTrack]: numOrg },
+            };
+          }
+        }
+      }
+    }
+  }
+}
+
+function* iterFindComboArgsSoundDropPermutations(): Generator<FindComboArgs> {
+  const maxCogLvl = 20;
+  const isLured = false;
+  for (const gags of [
+    { sound: 2, drop: 2 },
+    { sound: 3, drop: 1 },
+  ] satisfies FindComboArgs['gags'][]) {
+    for (let cogLvl = maxCogLvl; cogLvl >= 1; cogLvl--) {
+      for (const soundOrg of util.range(0, gags.sound)) {
+        for (const dropOrg of util.range(0, gags.drop)) {
+          yield {
+            minGagLvl: undefined,
+            isLured,
+            cogLvl,
+            gags,
+            organicGags: { sound: soundOrg, drop: dropOrg },
+          };
+        }
+      }
+    }
+  }
+}
 

--- a/src/gags.ts
+++ b/src/gags.ts
@@ -1,6 +1,7 @@
 import {
-  GagTrack, GagTracks, gags, gagTracksOrder, cogHp, SosToons, sosToonGags,
+  GagTrack, GagTracks, GAGS, GAG_TRACKS_ORDER, COG_HP, SosToons, SOS_TOON_GAGS, ADDITIONAL_GAG_MULTIPLIERS,
 } from './constants';
+import { clamp, defaultdict, Brand, assert } from './util';
 
 export class Cog {
   lvl: number;
@@ -15,7 +16,7 @@ export class Cog {
   }
 
   get hp(): number {
-    return cogHp[this.lvl];
+    return COG_HP[this.lvl];
   }
 
   toString(): string {
@@ -38,9 +39,16 @@ export class Gag {
     this.isOrg = isOrg;
   }
 
-  clone(): Gag {
+  /** Clone with optional `props` to override */
+  clone(props: {
+    track?: GagTrack;
+    lvl?: number;
+    isOrg?: boolean;
+  } = {}): Gag {
     return new Gag({
-      track: this.track, lvl: this.lvl, isOrg: this.isOrg
+      track: props.track ?? this.track,
+      lvl: props.lvl ?? this.lvl,
+      isOrg: props.isOrg ?? this.isOrg,
     });
   }
 
@@ -48,14 +56,14 @@ export class Gag {
     if (this.lvl === 0) {
       return 'None';
     }
-    return gags[this.track][this.lvl].name;
+    return GAGS[this.track][this.lvl].name;
   }
 
   get damage(): number {
     if (this.lvl === 0) {
       return 0;
     }
-    const baseDmg = gags[this.track][this.lvl].damage;
+    const baseDmg = GAGS[this.track][this.lvl].damage;
 
     if (this.isOrg && baseDmg > 0) {
       return baseDmg + Math.ceil(baseDmg * Gag.orgBonusMultiplier(this.track));
@@ -80,7 +88,7 @@ export class Gag {
    * Return true/false if the gag receives multi same gag type bonus,
    * and true/false if the gag receives knockback bonus.
    */
-  multipliers(combo: Combo, cog?: Cog): { multi: boolean; knockback: boolean; } {
+  multipliers(combo: Combo, isLured?: boolean): { multi: boolean; knockback: boolean; } {
     if (this.lvl === 0)
       return { multi: false, knockback: false };
 
@@ -94,16 +102,16 @@ export class Gag {
     const tc = combo.trackCounts();
     return {
       multi: tc[this.track] >= 2,
-      knockback: this.knockback(combo, cog),
+      knockback: this.knockback(combo, isLured),
     };
   }
 
-  knockback(combo: Combo, cog?: Cog): boolean {
+  knockback(combo: Combo, isLured?: boolean): boolean {
     const tc = combo.trackCounts();
     // 2 options for isLured:
     // - Cog already in lured state `cog.isLured`
     // - Cog to become lured from presence of lure gag in combo
-    if ((!cog || !cog.isLured) && tc['lure'] === 0)
+    if (!isLured && tc['lure'] === 0)
       return false;
     if (tc['trap'] > 0)
       return false;
@@ -121,7 +129,7 @@ export class Gag {
   }
 }
 
-type SosToonGagTrack = keyof typeof sosToonGags;
+type SosToonGagTrack = keyof typeof SOS_TOON_GAGS;
 
 export class SosToonGag extends Gag {
   declare track: SosToonGagTrack;
@@ -138,7 +146,7 @@ export class SosToonGag extends Gag {
     track: SosToonGagTrack,
     lvl: number,
   ): SosToonGag {
-    const { sosToon } = sosToonGags[track][lvl];
+    const { sosToon } = SOS_TOON_GAGS[track][lvl];
     return new SosToonGag(sosToon);
   }
 
@@ -185,25 +193,25 @@ export class SosToonGag extends Gag {
   }
 
   get sosToon(): SosToons {
-    return sosToonGags[this.track][this.lvl].sosToon;
+    return SOS_TOON_GAGS[this.track][this.lvl].sosToon;
   }
 
   override get name(): string {
-    return sosToonGags[this.track][this.lvl].name;
+    return SOS_TOON_GAGS[this.track][this.lvl].name;
   }
 
   override get damage(): number {
-    return sosToonGags[this.track][this.lvl].damage;
+    return SOS_TOON_GAGS[this.track][this.lvl].damage;
   }
 }
+
+export type ComboKey = Brand<string, 'ComboKey'>;
 
 export class Combo {
   gags: Array<Gag>;
 
-  constructor({ gags }: {
-    gags: Array<Gag>;
-  }) {
-    this.gags = gags;
+  constructor(arg: { gags: Array<Gag> } | Array<Gag>) {
+    this.gags = (Array.isArray(arg) ? arg : arg.gags).toSorted(sortFnGags);
   }
 
   /** Create new `Combo` instance, copied from another instance */
@@ -213,25 +221,10 @@ export class Combo {
     });
   }
 
-  /**
-   * Util omitting gag tracks entries with non 1+ values,
-   * and sorting the keys order to match the correct gag track order.
-   * Used for handling the constructor params `gagsInput` & `organicGagsInput`.
-   */
-  static cleanGagCounts(gagCounts: Partial<Record<GagTrack, number>>): Partial<Record<GagTrack, number>> {
-    return Object.values(GagTracks).reduce((acc, track) => {
-      if (gagCounts.hasOwnProperty(track) && gagCounts[track]! > 0)
-        acc[track] = gagCounts[track];
-      return acc;
-    }, {} as Partial<Record<GagTrack, number>>);
-  }
-
   /** A mapping of gag tracks to their respective number of gags in the combo */
   trackCounts(): Record<GagTrack, number> {
     return this.gags.reduce((acc, gag) => {
-      if (gag.lvl !== 0) {
-        acc[gag.track] += 1;
-      }
+      if (gag.lvl > 0) acc[gag.track] += 1;
       return acc;
     }, Object.fromEntries(Object.values(GagTracks).map(gt => [gt, 0])) as Record<GagTracks, number>);
   }
@@ -246,43 +239,30 @@ export class Combo {
     }, Object.fromEntries(Object.values(GagTracks).map(gt => [gt, 0])) as Record<GagTracks, number>);
   }
 
-  /**
-   * Returns an array of an array of gags, grouped by track,
-   * sorted in the usual gag track order.
-   * Level 0 (pass) gags are filtered out.
-   */
-  gagsGroupedByTrack(): Array<Array<Gag>> {
-    // Filter creates new array, we can sort without mutating `this.gags`
+  /** Groups gags by track, in the usual gag track order, with lvl 0 gags filtered out. */
+  gagsGroupedByTrack(): Partial<Record<GagTrack, Gag[]>> {
     const gags = this.gags
       .filter(g => g.lvl !== 0)
-      .sort(sortFnGags);
+      .toSorted(sortFnGags);
 
-    if (gags.length === 0) return [];
-
-    const groups: Array<Array<Gag>> = [[gags[0]]];
-    for (let i = 1; i < gags.length; i++) {
-      if (gags[i].track === gags[i - 1].track) {
-        groups[groups.length - 1].push(gags[i]);
-      } else {
-        groups.push([gags[i]]);
-      }
-    }
-    return groups;
+    return Object.groupBy(gags, (gag) => gag.track);
   }
 
-  damage({ cog, additionalGagMultiplier = 0, onlyTrack }: {
-    cog?: Cog;
+  damage({ isLured, additionalGagMultiplier = 0, onlyTrack }: {
+    isLured?: boolean;
     additionalGagMultiplier?: number;
     onlyTrack?: GagTrack;
   } = {}): number {
-    return this.gagsGroupedByTrack().reduce((dmg, gags) => {
-      if (onlyTrack && gags[0].track !== onlyTrack)
+    return Object.entries(this.gagsGroupedByTrack()).reduce((dmg, [track, gags]) => {
+      if (onlyTrack && track !== onlyTrack)
         return dmg;
       // If multiple traps are in the combo, they cancel each other out, don't included the trap damage
-      if (gags[0].track === GagTracks.trap && gags.length >= 2)
+      if (track === GagTracks.trap && gags.length >= 2)
         return dmg;
 
-      const { multi, knockback } = gags[0].multipliers(this, cog);
+      const { multi, knockback } = gags[0].multipliers(this, isLured);
+
+      // TODO Could probably write a cleaner version of this..? vs the 2 blocks with repetition
 
       // https://github.com/zzzachzzz/toontown-combos/issues/34#issuecomment-2282841602
       // "When damage is reduced (+25% Defense) it applies to the gags..."
@@ -319,61 +299,90 @@ export class Combo {
   }
 
   damageKillsCog(cog: Cog, additionalGagMultiplier?: number): boolean {
-    return this.damage({ cog, additionalGagMultiplier }) >= cog.hp;
+    return this.damage({ isLured: cog.isLured, additionalGagMultiplier }) >= cog.hp;
+  }
+
+  toKey(): ComboKey {
+    const parts: string[] = this.gags.toSorted(sortFnGags).map(gag => {
+      if (gag.lvl === 0) return "no";
+      const gt = gagTrackAbbrev(gag.track, gag.isOrg);
+      return `${gt}${gag.lvl}`;
+    });
+
+    return parts.join('_') as ComboKey;
+  }
+
+  static fromKey(key: ComboKey): Combo {
+    return new Combo({
+      gags: key.split('_').map(part => {
+        const gagTrackAbbrev = part.substring(0, 2);
+        const track = gagTrackAbbrevLookup[
+          gagTrackAbbrev.toLowerCase() as GagTrackAbbrev<GagTrack, false>
+        ];
+        const lvl = Number(part[2]);
+        if (!track || isNaN(lvl)) throw new Error(`Bad combo key '${key}'`);
+        const isOrg = part.startsWith(part.charAt(0).toUpperCase());
+        return new Gag({ track, lvl, isOrg });
+      })
+    });
   }
 }
 
 export class FindComboResult {
-  combo: Combo;
-  cog: Cog;
-  gagsInput: Partial<Record<GagTrack, number>>;
-  organicGagsInput: Partial<Record<GagTrack, number>>;
-  additionalGagMultiplier?: number;
+  args: FindComboArgs;
+  combo: Combo | null;
 
-  constructor({ combo, cog, gagsInput, organicGagsInput, additionalGagMultiplier }: {
-    combo: Combo;
-    cog: Cog;
-    gagsInput: Partial<Record<GagTrack, number>>;
-    organicGagsInput: Partial<Record<GagTrack, number>>;
-    additionalGagMultiplier?: number;
-  }) {
+  constructor(args: FindComboArgs, combo: Combo | null) {
     this.combo = combo
-    this.cog = cog;
-    this.gagsInput = Combo.cleanGagCounts(gagsInput ?? {});
-    this.organicGagsInput = Combo.cleanGagCounts(organicGagsInput ?? {});
-    this.additionalGagMultiplier = additionalGagMultiplier;
+    this.args = {
+      ...args,
+      gags: cleanGagCounts(args.gags),
+      organicGags: cleanGagCounts(args.organicGags),
+    };
   }
 
-  inputKey() {
-    const cog = { lvl: this.cog.lvl, isLured: this.cog.isLured };
-    const gags = this.gagsInput;
-    const organicGags = this.organicGagsInput;
-
-    return { cog, gags, organicGags };
+  inputKey(): FindComboArgsKey {
+    return findComboArgsToKey(this.args);
   }
 
-  outputKey() {
-    const gags = [...this.combo.gags]
-      .sort(sortFnGags)
-      .map(gag => {
-        const dmg = gag.damage;
-        const { lvl, track } = gag;
-        const { multi, knockback } = gag.multipliers(this.combo, this.cog);
-        return { track, lvl, dmg, multi, knockback };
-      })
-
-    const dmg = this.combo.damage({ cog: this.cog, additionalGagMultiplier: this.additionalGagMultiplier });
-
-    return { dmg, gags };
+  outputKey(): ComboKey {
+    if (!this.combo) return "" as ComboKey;
+    return this.combo.toKey();
   }
 
   damage(): number {
-    return this.combo.damage({ cog: this.cog, additionalGagMultiplier: this.additionalGagMultiplier });
+    if (!this.combo) return 0;
+    const { isLured, additionalGagMultiplier } = this.args;
+    return this.combo.damage({ isLured, additionalGagMultiplier });
   }
 
-  damageKillsCog(): boolean {
-    return this.combo.damageKillsCog(this.cog);
+
+  shortView() {
+    return {
+      damage: `${this.damage()}/${this.cog.hp}`,
+      inputKey: this.inputKey(),
+      outputKey: this.outputKey(),
+    };
   }
+
+  get cog(): Cog {
+    const { cogLvl: lvl, isLured } = this.args;
+    return new Cog({ lvl, isLured });
+  }
+}
+
+/**
+ * Util omitting gag tracks entries with non 1+ values,
+ * and sorting the keys order to match the correct gag track order.
+ */
+export function cleanGagCounts(
+  gagCounts: Partial<Record<GagTrack, number>>
+): Partial<Record<GagTrack, number>> {
+  return Object.values(GagTracks).reduce((acc, track) => {
+    if (gagCounts.hasOwnProperty(track) && gagCounts[track]! > 0)
+      acc[track] = gagCounts[track];
+    return acc;
+  }, {} as Partial<Record<GagTrack, number>>);
 }
 
 export type FindComboArgs = {
@@ -385,186 +394,327 @@ export type FindComboArgs = {
    */
   gags: Partial<Record<GagTrack, number>>;
   organicGags: Partial<Record<GagTrack, number>>;
-  minGagLvl?: number | null;
+  minGagLvl?: number;
+  additionalGagMultiplier?: number;
 };
 
-export function findCombo({
-  cogLvl,
-  isLured,
-  gags,
-  organicGags,
-  minGagLvl = null,
-}: FindComboArgs): FindComboResult {
-  // Validate `gags` input
+type GagTrackAbbrev<
+  GT extends GagTrack,
+  Org extends boolean,
+> = GT extends `${infer A}${infer B}${string}`
+    ? Org extends true
+      ? `${Uppercase<A>}${B}`
+      : `${A}${B}`
+    : never;
+
+function gagTrackAbbrev<
+  GT extends GagTrack,
+  Org extends boolean,
+>(gagTrack: GT, isOrg: Org): GagTrackAbbrev<GT, Org> {
+  return (
+    isOrg
+    ? gagTrack[0].toUpperCase() + gagTrack[1]
+    : gagTrack[0] + gagTrack[1]
+  ) as GagTrackAbbrev<GT, Org>;
+}
+
+const gagTrackAbbrevLookup: { [GT in GagTracks as GagTrackAbbrev<GT, false>]: GT } = {
+  to: GagTracks.toonup,
+  tr: GagTracks.trap,
+  lu: GagTracks.lure,
+  so: GagTracks.sound,
+  th: GagTracks.throw,
+  sq: GagTracks.squirt,
+  dr: GagTracks.drop,
+};
+
+export type FindComboArgsKey = Brand<string, 'FindComboArgsKey'>;
+
+/** {@link findComboArgs} assumed to be validated already by {@link validateFindComboArgs} */
+export function findComboArgsToKey(findComboArgs: FindComboArgs): FindComboArgsKey {
+  const { gags, organicGags, minGagLvl, cogLvl, isLured, additionalGagMultiplier } = findComboArgs;
+
+  const parts: string[] = [];
+
+  for (const [gagTrack, numGags] of Object.entries(cleanGagCounts(gags)) as [GagTrack, number][]) {
+    let numOrg = organicGags[gagTrack] ?? 0;
+    parts.push(...Array.from(
+      { length: numGags },
+      () => gagTrackAbbrev(gagTrack, numOrg-- > 0)
+    ));
+  }
+
+  if (minGagLvl != null) parts.push(`min${minGagLvl}`);
+
+  parts.push(`c${cogLvl}`);
+
+  if (isLured) parts.push('l');
+
+  if (additionalGagMultiplier) parts.push(`*${additionalGagMultiplier}`);
+
+  return parts.join('_') as FindComboArgsKey;
+}
+
+export function keyToFindComboArgs(key: FindComboArgsKey): Partial<FindComboArgs> {
+  const _findComboArgs: Partial<FindComboArgs> = {
+    gags: {},
+    organicGags: {},
+    isLured: false,
+  };
+
+  const gags = defaultdict(_findComboArgs.gags!, () => 0);
+  const organicGags = defaultdict(_findComboArgs.organicGags!, () => 0);
+
+  return key.split('_').reduce((findComboArgs, part) => {
+    if (part.startsWith('*')) {
+      findComboArgs.additionalGagMultiplier = Number(part.substring(1));
+      return findComboArgs;
+    }
+    if (part === 'l') {
+      findComboArgs.isLured = true;
+      return findComboArgs;
+    }
+    if (part.startsWith('c')) {
+      findComboArgs.cogLvl = Number(part.substring(1));
+      return findComboArgs;
+    }
+    if (part.startsWith('min')) {
+      findComboArgs.minGagLvl = Number(part.substring(3));
+      return findComboArgs;
+    }
+    for (const gagTrack of Object.values(GagTracks)) {
+      if (gagTrack.startsWith(part.toLowerCase())) {
+        gags[gagTrack] += 1;
+        if (part.startsWith(gagTrack.charAt(0).toUpperCase())) {
+          organicGags[gagTrack] += 1;
+        }
+        return findComboArgs;
+      }
+    }
+    return findComboArgs;
+  }, _findComboArgs);
+}
+
+/** Assert result of {@link keyToFindComboArgs} */
+export function assertFindComboArgs(
+  findComboArgs: Partial<FindComboArgs>
+): asserts findComboArgs is FindComboArgs {
+  const { gags, organicGags, minGagLvl, cogLvl, isLured, additionalGagMultiplier } = findComboArgs;
+  const err = new Error(`Invalid \`FindComboArgs\` object:\n${findComboArgs}`);
+
+  if (!gags) throw err;
+  if (!organicGags) throw err;
+  if (isNaN(minGagLvl!)) throw err;
+  if (isNaN(cogLvl!)) throw err;
+  if (isLured == null) throw err;
+  if (isNaN(additionalGagMultiplier!)) throw err;
+}
+
+export function validateFindComboArgs(args: FindComboArgs): void {
+  const { cogLvl, gags, organicGags, minGagLvl /* isLured, additionalGagMultiplier */ } = args;
+
+  validateGagTrackRecord(gags, 'gags' satisfies keyof typeof args);
+  validateGagTrackRecord(organicGags, 'organicGags' satisfies keyof typeof args);
+
+  // Validate `minGagLvl` input
+  if (minGagLvl != null && (minGagLvl < 1 || minGagLvl > 7)) {
+    throw new Error(`\`minGagLvl\` argument must be 1 <= n <= 7. Received ${minGagLvl}.`);
+  }
+
+  // Validate `cogLvl` input
+  if (cogLvl < 1 || cogLvl > 20) {
+    throw new Error(`\`cogLvl\` argument must be 1 <= n <= 7. Received ${cogLvl}.`);
+  }
+}
+
+function validateGagTrackRecord(
+  gagTrackRecord: Partial<Record<GagTrack, number>>,
+  argName: keyof Pick<FindComboArgs, 'gags' | 'organicGags'>
+) {
   let sumGags = 0;
-  for (const [key, val] of Object.entries(gags)) {
+  for (const [key, val] of Object.entries(gagTrackRecord)) {
     if (!GagTracks.hasOwnProperty(key)) {
       throw new Error(
-        `Unrecognized gag track key '${key}' in \`gags\` argument. ` +
+        `Unrecognized gag track key '${key}' in \`${argName}\` argument. ` +
         `Must be one of: ${Object.values(GagTracks).map(gt => "'" + gt + "'").join(', ')}`
       );
     }
     if (typeof val !== 'number' || isNaN(val)) {
-      throw new Error(`Values in \`gags\` argument must be a number. For key '${key}' got value '${val}'.`);
+      throw new Error(`Values in \`${argName}\` argument must be a number. For key '${key}' got value '${val}'.`);
     }
     if (key === 'trap' && val > 1) {
-      throw new Error(`Cannot specify multiple trap gags, must be 0 or 1.`);
+      throw new Error(`${val} trap gags specified in argument \`${argName}\`. Must be 0 or 1.`);
     }
     sumGags += val;
   }
-  if (sumGags < 1 || sumGags > 4) {
-    throw new Error(`Sum of values in \`gags\` argument must be 1 <= n <= 4. Received ${sumGags}.`);
+  const minSumGags = argName === 'gags' ? 1 : 0;
+  if (sumGags < minSumGags || sumGags > 4) {
+    throw new Error(`Sum of values in \`${argName}\` argument must be ${minSumGags} <= n <= 4. Received ${sumGags}.`);
   }
-
-  // Validate `minGagLvl` input
-  if (minGagLvl !== null && (minGagLvl < 1 || minGagLvl > 7)) {
-    throw new Error(`\`minGagLvl\` argument must be 1 <= n <= 7. Received ${minGagLvl}.`);
-  }
-
-  const comboGags: Array<Gag> = Object.entries(gags).reduce((acc, [track, numGags]) => {
-    for (let i = 0; i < numGags; i++) {
-      const isOrg = i <= (organicGags[track as GagTrack] ?? 0) - 1;
-      acc.push(new Gag({
-        track: track as GagTrack,
-        lvl: minGagLvl ?? 1,
-        isOrg,
-      }));
-    }
-    return acc;
-  }, [] as Array<Gag>);
-
-  // Sort by damage high to low for the algorithm
-  comboGags.sort((gag1, gag2) => gag2.damage - gag1.damage);
-
-  const cog = new Cog({ lvl: cogLvl, isLured });
-
-  let combo = new Combo({ gags: comboGags });
-
-  combo = _findCombo(combo, cog, minGagLvl);
-
-  combo.gags.sort(sortFnGags);
-
-  return new FindComboResult({
-    combo,
-    cog,
-    gagsInput: gags,
-    organicGagsInput: organicGags,
-  });
 }
 
-/**
- * Core combo algorithm. Note that the `combo` argument is mutated.
- */
-function _findCombo(
-  combo: Combo,
-  cog: Cog,
-  minGagLvl: number | null,
-): Combo {
-  // Increase the level of each gag until the damage is sufficient
-  while (!combo.damageKillsCog(cog)) {
-    for (const gag of combo.gags) {
-      if (gag.lvl === 7) {
-        continue;
-      } else {
-        gag.lvl += 1;
-      }
+export function findCombo(args: FindComboArgs): Combo | null {
+  validateFindComboArgs(args);
+
+  const { cogLvl, isLured, gags, organicGags: _organicGags, minGagLvl, additionalGagMultiplier } = args;
+
+  const comboGags: Gag[] = Object.entries(gags)
+    .reduce<Gag[]>((acc, [track, numGags]) => {
+      return acc.concat(
+        Array.from({ length: numGags }, () => new Gag({
+          track: track as GagTrack,
+          lvl: minGagLvl ?? 0,
+        }))
+      );
+    }, []);
+
+  const organicGags = new Proxy(_organicGags, {
+    get(target, name) {
+      const track = name as GagTrack;
+      if (!(track in target)) target[track] = 0;
+      const value = target[track]!;
+      return clamp(value, 0, gags[track] ?? 0);
     }
-    if (combo.gags.every(gag => gag.lvl === 7))
-      break;
+  }) as Record<GagTrack, number>;
+
+  let combo = new Combo({ gags: comboGags });
+  const cog = new Cog({ lvl: cogLvl, isLured });
+
+  const damageKillsCog = (c: Combo) => c.damageKillsCog(cog, additionalGagMultiplier);
+
+  // Upgrade combo gag levels/orgs until the damage is sufficient
+  while (
+       !damageKillsCog(combo)
+    && canComboCloneUp(combo, organicGags)
+  ) {
+    combo = comboCloneUp(combo, organicGags);
   }
 
   // Insufficient damage, killing cog with given parameters is not possible
-  if (!combo.damageKillsCog(cog)) {
-    combo.gags = combo.gags.map(g => new Gag({ track: g.track, lvl: 0, isOrg: g.isOrg }));
-    return combo;
+  if (!damageKillsCog(combo)) return null;
+
+  // Downgrade combo gag levels/orgs until the damage is insufficient
+  while (canComboCloneDown(combo)) {
+    const candidate = comboCloneDown(combo);
+    if (!damageKillsCog(candidate)) break;
+    combo = candidate;
   }
 
-  // Decrease the level of individual gags until the damage is insufficient
-  let i = 0;
-  while (i !== combo.gags.length-1) {
-    for (i = combo.gags.length-1; i >= 0; i--) {
-      if (combo.gags[i].lvl === 0) {
-        break;
-      }
-      if (minGagLvl !== null && combo.gags[i].lvl === minGagLvl) {
-        combo.gags[i].lvl = 0;
-        if (!combo.damageKillsCog(cog)) {
-          combo.gags[i].lvl = minGagLvl;
-          break
-        }
-      } else {
-        combo.gags[i].lvl -= 1;
-        if (!combo.damageKillsCog(cog)) {
-          combo.gags[i].lvl += 1;
-          break
-        }
-      }
-    }
-  }
-
-  const orgsAvailable = combo.orgTrackCounts();
-
-  // Check if organics are necessary for combo
-  for (const gag of combo.gags)
-    gag.isOrg = false;
-
-  /**
-   * Optimize combo by prioritizing low level organics over high level organics.
-   * May require multiple passes... see comments in function calls below.
-   */
-  const tryOptimizeOrganics = (combo: Combo): Combo => {
-    for (let i = combo.gags.length - 1; i >= 0; i--) {
-      const gag = combo.gags[i];
-      if (orgsAvailable[gag.track] === 0)
-        continue;
-      if (combo.orgTrackCounts()[gag.track] >= orgsAvailable[gag.track]) {
-        for (let j = combo.gags.length - 1; j >= 0; j--) {
-          const gag2 = combo.gags[j];
-          if (gag2.track === gag.track && gag2.isOrg) {
-            gag2.isOrg = false;
-            break;
-          }
-        }
-      }
-      if (combo.damageKillsCog(cog))
-        break;
-      if (gag.lvl > 0)
-        gag.isOrg = true;
-      if (combo.damageKillsCog(cog))
-        break;
-    }
-    return combo;
-  };
-
-  // Yeah this is stupid... 2 passes seems to suffice. A combo where 2 passes are required is:
-  // Lvl 10 cog 132 hp
-  // 4 sound, 2 org sound
-  // Fog (org) | Trunk | Aoogah (org) | Aoogah
-  // 132 damage
-  combo = tryOptimizeOrganics(combo);
-  combo = tryOptimizeOrganics(combo);
-
-  // If drop combo, keep other gags around for stun bonus even if the damage is unneeded
-  if (combo.trackCounts()['drop'] > 0) {
-    for (let i = 0; i < combo.gags.length; i++) {
-      if (combo.gags[i].track !== 'drop' && combo.gags[i].lvl === 0) {
-        combo.gags[i].lvl = minGagLvl ?? 1;
-      }
-    }
+  if (minGagLvl) {
+    combo = new Combo({
+      gags: combo.gags.map(gag =>
+        gag.lvl < minGagLvl && gag.lvl > 0
+        ? gag.clone({ lvl: minGagLvl, isOrg: false })
+        : gag
+      )
+    });
   }
 
   return combo;
 }
 
+export function canComboCloneUp(
+  combo: Combo,
+  organicGags: Record<GagTrack, number>
+): boolean {
+  const orgCounts = combo.orgTrackCounts();
+
+  return combo.gags.some(g => {
+    if (g.lvl < 7) return true;
+    if (g.isOrg) return false;
+    const orgsAvailable = organicGags[g.track] - orgCounts[g.track];
+    return orgsAvailable > 0;
+  });
+}
+
+export function comboCloneUp(
+  combo: Combo,
+  organicGags: Record<GagTrack, number>
+): Combo {
+  const orgCounts = combo.orgTrackCounts();
+  const gagsLowToHigh = combo.gags.toSorted(sortFnGagsLowest);
+  const lowest = gagsLowToHigh.at(0)!;
+  const { track } = lowest;
+  const gagsLowToHighOfTrack = gagsLowToHigh.filter(g => g.track === track);
+  const orgsAvailable = organicGags[track] - orgCounts[track];
+
+  assert(() => orgsAvailable >= 0);
+
+  const lowestNonOrg = gagsLowToHighOfTrack
+    .filter(g => !g.isOrg && g.lvl > 0)
+    .at(0);
+
+  // 1. Up lowest non-org gag to org
+  if (orgsAvailable > 0 && lowestNonOrg) {
+    return new Combo(combo.gags.map(
+      g => g === lowestNonOrg
+           ? g.clone({ isOrg: true })
+           : g.clone()
+    ));
+  }
+
+  // During cloneUp phase, gag level differential never exceeds 1
+  const lowestOrg = gagsLowToHighOfTrack.find(g => g.isOrg);
+  const nearestLvlUpNonOrg = lowestOrg &&
+    gagsLowToHighOfTrack.find(g => g.lvl > lowestOrg.lvl && !g.isOrg);
+
+  // 2. Switch low level org for higher level org
+  if (orgsAvailable === 0 && lowestOrg && nearestLvlUpNonOrg) {
+    return new Combo(combo.gags.map(
+      g => g === lowestOrg
+           ? g.clone({ isOrg: false })
+           : g === nearestLvlUpNonOrg
+             ? g.clone({ isOrg: true })
+             : g.clone()
+    ));
+  }
+
+  // 3. Gag level up, make everything non-org
+  return new Combo(combo.gags.map(
+    g => g === lowest
+         ? g.clone({ lvl: g.lvl + 1, isOrg: false })
+         : g.clone({ isOrg: false })
+  ));
+}
+
+export function canComboCloneDown(combo: Combo): boolean {
+  return combo.gags.some(gag => gag.lvl > 0);
+}
+
+/**
+ * Note that this does not downgrade organics, only levels.
+ * Works in the context of the overall {@link findCombo} algorithm leveraging {@link comboCloneUp}.
+ */
+export function comboCloneDown(combo: Combo): Combo {
+  const low = combo.gags.toSorted(sortFnGagsLowest).find(g => g.lvl > 0);
+  assert(() => !!low);
+  return new Combo(combo.gags.map(
+    g => g === low
+         ? g.clone({ lvl: g.lvl - 1 })
+         : g.clone()
+  ));
+}
+
 /** Sort gags based on track order, then damage high to low. */
 export function sortFnGags(gag1: Gag, gag2: Gag): number {
-  const cmpTrack = gagTracksOrder[gag1.track] - gagTracksOrder[gag2.track];
-  if (cmpTrack !== 0) return cmpTrack;
-  return gag2.damage - gag1.damage;
+  return (
+       GAG_TRACKS_ORDER[gag1.track] - GAG_TRACKS_ORDER[gag2.track]
+    || gag2.damage - gag1.damage
+    || Number(gag2.isOrg) - Number(gag1.isOrg) // For 0 dmg gags (toonup, lure), fallback for sort predictability
+  );
+}
+
+export function sortFnGagsLowest(gag1: Gag, gag2: Gag): number {
+  return (
+       gag1.lvl - gag2.lvl
+    || gag1.damage - gag2.damage
+    || GAG_TRACKS_ORDER[gag1.track] - GAG_TRACKS_ORDER[gag2.track]
+    || Number(gag1.isOrg) - Number(gag2.isOrg) // For 0 dmg gags (toonup, lure), fallback for sort predictability
+  );
 }
 
 export function logTable(findComboRes: FindComboResult): void {
-  const { combo, cog, additionalGagMultiplier } = findComboRes;
+  const { combo, cog, args: { isLured, cogLvl, additionalGagMultiplier } } = findComboRes;
 
   const fmtInputGags = (gags: Partial<Record<GagTrack, number>>) => {
     const _gags = Object.entries(gags)
@@ -576,16 +726,22 @@ export function logTable(findComboRes: FindComboResult): void {
 
   console.log('Input:');
   console.table({
-    'Cog Level': cog.lvl,
-    'Is Cog Lured?': cog.isLured,
-    'Gags': fmtInputGags(findComboRes.gagsInput),
-    'Organic Gags': fmtInputGags(findComboRes.organicGagsInput),
+    'Cog Level': cogLvl,
+    'Is Cog Lured?': isLured,
+    'Gags': fmtInputGags(findComboRes.args.gags),
+    'Organic Gags': fmtInputGags(findComboRes.args.organicGags),
+    ...(additionalGagMultiplier && {
+      'Additional Gag Multiplier': (
+        additionalGagMultiplier in ADDITIONAL_GAG_MULTIPLIERS
+        ? ADDITIONAL_GAG_MULTIPLIERS[additionalGagMultiplier]
+        : additionalGagMultiplier
+      )
+    }),
   });
-  // TODO Additional support for logging of `additionalGagMultiplier`
   console.log('Combo:');
   console.table(
-    combo.gags.reduce((newObj, gag, i) => {
-      const { multi, knockback } = gag.multipliers(combo, cog);
+    combo?.gags.reduce((newObj, gag, i) => {
+      const { multi, knockback } = gag.multipliers(combo, isLured);
       const multipliers = [];
       if (multi)
         multipliers.push('Same type bonus (20%)');
@@ -604,7 +760,7 @@ export function logTable(findComboRes: FindComboResult): void {
 
   console.log('Details:');
   console.table({
-    'Final damage calculated': combo.damage({ cog, additionalGagMultiplier }),
+    'Final damage calculated': combo?.damage({ isLured, additionalGagMultiplier }),
     'Cog HP': cog.hp,
   });
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,6 @@
 import { createMemo, createSignal } from 'solid-js';
 import { createStore as _createStore } from 'solid-js/store';
-import { findCombo, FindComboResult, Combo } from './gags';
+import { findCombo, Combo } from './gags';
 import * as util from './util';
 import type { GagTrack } from './constants';
 import type { SavedState } from './local-storage';
@@ -131,12 +131,12 @@ export const createStore = ({
       return 20;
     };
 
-    getComboGridCombos = createMemo((): Array<FindComboResult> => {
+    getComboGridCombos = createMemo((): Array<Combo | null> => {
       const maxCogLvl = this.getMaxCogLvl();
       const organicGags = this.getSelectedOrgGagTrackCounts();
       const isLured = this.getIsLured();
       const level4UpGagsOnly = this.getLevel4UpGagsOnly();
-      const minGagLvl = level4UpGagsOnly ? 4 : null;
+      const minGagLvl = level4UpGagsOnly ? 4 : undefined;
 
       return Array.from(
         util.iterFindComboArgs({ maxCogLvl, organicGags, isLured, minGagLvl }),

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -7,7 +7,7 @@ expect.addSnapshotSerializer({
       {
         cog: findComboRes.cog,
         damage: findComboRes.damage(),
-        gags: findComboRes.combo.gags,
+        gags: findComboRes.combo?.gags,
       },
       config,
       indentation,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,24 @@
 import type { FindComboArgs } from './gags';
-import { GagTrack, GagTracks, BASE_URL, gags, SosToons } from './constants';
+import { GagTrack, GagTracks, BASE_URL, GAGS, SosToons } from './constants';
+
+declare const __brand: unique symbol;
+export type Brand<T, B extends string> = T & { [__brand]: B };
+
+export function defaultdict<T extends Record<string, any>>(
+  obj: T,
+  factory: () => T[keyof T]
+): Required<T> {
+  return new Proxy(obj, {
+    get(target, name) {
+      if (!(name in target)) target[name as keyof T] = factory();
+      return target[name as keyof T];
+    }
+  }) as Required<T>;
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
 
 export function* batch<T>(batchSize: number, iterable: Iterable<T>): Generator<Array<T>> {
   let yieldNext: Array<T> = [];
@@ -40,6 +59,17 @@ export function* range(start: number, end: number, step: number = 1): Generator<
   }
 }
 
+export function assert(
+  fn: () => boolean,
+  msg?: string,
+): asserts fn is (() => true) {
+  if (fn()) return;
+  const condition = fn.toString()
+    .replace(/^\(\)\s*=>\s*/, '')
+    .trim();
+  throw new Error(`Assertion failed (${condition})${msg ? (': ' + msg) : ''}`);
+}
+
 export function* iterFindComboArgs({
   maxCogLvl,
   organicGags,
@@ -50,7 +80,7 @@ export function* iterFindComboArgs({
   'organicGags' | 'isLured' | 'minGagLvl'>
 ): Generator<FindComboArgs> {
   const common = { isLured, organicGags, minGagLvl };
-  const gagTracks: Array<GagTrack> = ['sound', 'throw', 'squirt'];
+  const gagTracks: Array<GagTrack> = [GagTracks.sound, GagTracks.throw, GagTracks.squirt];
   for (let cogLvl = maxCogLvl; cogLvl >= 1; cogLvl--) {
     for (const gagTrack of gagTracks) {
       for (let numToons = 4; numToons >= 1; numToons--) {
@@ -65,7 +95,7 @@ export const getResourceUrl = (path: string): string => `${BASE_URL}${path}`;
 export const getGagIconUrl = ({ track, lvl }: { track: GagTrack; lvl: number; }): string => {
   const iconName = lvl === 0
     ? 'None'
-    : gags[track][lvl].name.replace(/\s/g, '_');
+    : GAGS[track][lvl].name.replace(/\s/g, '_');
   return getResourceUrl(`gag_icons/${iconName}.png`);
 };
 


### PR DESCRIPTION
- Mutation free `findCombo` algorithm refactor with `comboCloneUp`, `comboCloneDown`, `sortFnGagsLowest`
- Nullable `Combo` return value from `findCombo` when combo does not kill cog
- Move `cleanGagCounts` out of `Combo` class to standalone function
- Simplified `gagsGroupedByTrack` with `Object.groupBy`
- Rename constants to UPPER_CASE to avoid name confusion with local vars
- Remove `gagTracksArray` in favor of inline `Object.values(GagTracks)`
- `findCombo` tests including all available organic permutations for...
  - All permutations relevant to combo grid (sound, throw, squirt)
  - All 2sound2drop & 3sound1drop permutations
- `util.ts` utils:
  - `defaultdict`
  - `clamp`
  - `assert`
  - Branded types with `Brand<T, B extends string>`
- `Combo.toKey` & `Combo.fromKey` as approximate successors to
  `FindComboResult.inputKey` & `FindComboResult.outputKey`.
  Uses new concise string DSL for concise representation of a `Combo`.
- Further validation of `FindComboArgs` with `validateFindComboArgs`
- Verify `additionalGagMultiplier` arg works in `findCombo`
- `logTable` output `additionalGagMultiplier` arg
- `.gitattributes` mark `*.snap` files as `linguist-generated`